### PR TITLE
Made `Discover page` posters expandable

### DIFF
--- a/src/core/api/tv_maze/series_information.rs
+++ b/src/core/api/tv_maze/series_information.rs
@@ -1,4 +1,5 @@
 use super::episodes_information::Episode;
+pub use super::Rating;
 use super::*;
 use serde::{Deserialize, Serialize};
 use std::hash::{Hash, Hasher};

--- a/src/gui/helpers.rs
+++ b/src/gui/helpers.rs
@@ -164,3 +164,16 @@ pub mod time {
         (word, time_value)
     }
 }
+
+pub fn genres_with_pipes(genres: &[String]) -> String {
+    let mut genres_string = String::new();
+
+    let mut series_result_iter = genres.iter().peekable();
+    while let Some(genre) = series_result_iter.next() {
+        genres_string.push_str(genre);
+        if series_result_iter.peek().is_some() {
+            genres_string.push_str(" | ");
+        }
+    }
+    genres_string
+}

--- a/src/gui/series_page/series/data_widgets.rs
+++ b/src/gui/series_page/series/data_widgets.rs
@@ -63,16 +63,7 @@ pub fn genres_widget(
 ) {
     if !series_info.genres.is_empty() {
         let title_text = text("Genres");
-        let mut genres = String::new();
-
-        let mut series_result_iter = series_info.genres.iter().peekable();
-        while let Some(genre) = series_result_iter.next() {
-            genres.push_str(genre);
-            if series_result_iter.peek().is_some() {
-                genres.push_str(" | ");
-            }
-        }
-        let genres = text(genres);
+        let genres = text(helpers::genres_with_pipes(&series_info.genres));
 
         data_grid.insert(title_text);
         data_grid.insert(genres);

--- a/src/gui/series_page/series/series_suggestion_widget.rs
+++ b/src/gui/series_page/series/series_suggestion_widget.rs
@@ -99,7 +99,7 @@ impl SeriesSuggestion {
                         Wrap::with_elements(
                             self.suggested_series
                                 .iter()
-                                .map(|poster| poster.normal_view().map(Message::SeriesPoster))
+                                .map(|poster| poster.normal_view(false).map(Message::SeriesPoster))
                                 .collect(),
                         )
                         .line_spacing(5.0)

--- a/src/gui/tabs/discover_tab/mod.rs
+++ b/src/gui/tabs/discover_tab/mod.rs
@@ -277,11 +277,15 @@ fn series_posters_loader<'a>(
             .padding(10)
             .into()
     } else {
-        let wrapped_posters =
-            Wrap::with_elements(posters.iter().map(|poster| poster.normal_view()).collect())
-                .spacing(5.0)
-                .line_spacing(5.0)
-                .padding(5.0);
+        let wrapped_posters = Wrap::with_elements(
+            posters
+                .iter()
+                .map(|poster| poster.normal_view(true))
+                .collect(),
+        )
+        .spacing(5.0)
+        .line_spacing(5.0)
+        .padding(5.0);
 
         column!(title, wrapped_posters)
             .spacing(5)
@@ -521,7 +525,7 @@ mod full_schedule_posters {
                                 self.monthly_new_poster
                                     .iter()
                                     .map(|poster| {
-                                        poster.normal_view().map(Message::MonthlyNewPosters)
+                                        poster.normal_view(true).map(Message::MonthlyNewPosters)
                                     })
                                     .collect(),
                             )
@@ -541,7 +545,9 @@ mod full_schedule_posters {
                                 self.monthly_returning_posters
                                     .iter()
                                     .map(|poster| {
-                                        poster.normal_view().map(Message::MonthlyReturningPosters)
+                                        poster
+                                            .normal_view(true)
+                                            .map(Message::MonthlyReturningPosters)
                                     })
                                     .collect(),
                             )
@@ -557,7 +563,7 @@ mod full_schedule_posters {
                         Wrap::with_elements(
                             self.popular_posters
                                 .iter()
-                                .map(|poster| poster.normal_view().map(Message::PopularPosters))
+                                .map(|poster| poster.normal_view(true).map(Message::PopularPosters))
                                 .collect()
                         )
                         .spacing(5.0)
@@ -752,7 +758,7 @@ mod full_schedule_posters {
                 Wrap::with_elements(
                     series_posters
                         .iter()
-                        .map(|series_poster| series_poster.normal_view().map(message))
+                        .map(|series_poster| series_poster.normal_view(true).map(message))
                         .collect(),
                 )
                 .spacing(5.0)

--- a/src/gui/tabs/my_shows_tab/my_shows_widget.rs
+++ b/src/gui/tabs/my_shows_tab/my_shows_widget.rs
@@ -139,7 +139,7 @@ impl MyShows {
             Wrap::with_elements(
                 self.series_posters
                     .iter()
-                    .map(|poster| poster.normal_view().map(Message::SeriesPosters))
+                    .map(|poster| poster.normal_view(false).map(Message::SeriesPosters))
                     .collect(),
             )
             .line_spacing(5.0)


### PR DESCRIPTION
This PR adds the functionality to expand a poster in `Discover page` by right clicking on it. This will show full name of the series (useful if it was truncated in the first place in normal view), it's genres, premier date and rating. This will be useful to quickly inspect a Show without visiting it's page.