### PR TITLE
Fix search results panel when no results

### DIFF
--- a/src/gui/tabs/discover_tab/searching.rs
+++ b/src/gui/tabs/discover_tab/searching.rs
@@ -132,8 +132,6 @@ impl Search {
                 Some(if result_items.is_empty() {
                     container(text("No results"))
                         .padding(10)
-                        .height(Length::Fill)
-                        .width(Length::Fill)
                         .center_x()
                         .center_y()
                         .into()

--- a/src/gui/tabs/discover_tab/searching.rs
+++ b/src/gui/tabs/discover_tab/searching.rs
@@ -130,11 +130,7 @@ impl Search {
                     .collect();
 
                 Some(if result_items.is_empty() {
-                    container(text("No results"))
-                        .padding(10)
-                        .center_x()
-                        .center_y()
-                        .into()
+                    container(text("No results")).padding(10).into()
                 } else {
                     Column::with_children(result_items)
                         .padding(20)


### PR DESCRIPTION
This PR fixes the search result panel when no results found, preventing it to occupy the whole discover page.