### PR TITLE
Prevent multiple downloads when loading full-schedule episodes

### DIFF
--- a/src/gui/series_page/series/series_suggestion_widget.rs
+++ b/src/gui/series_page/series/series_suggestion_widget.rs
@@ -12,7 +12,7 @@ use iced_aw::{Spinner, Wrap};
 
 #[derive(Debug, Clone)]
 pub enum Message {
-    FullScheduleLoaded(full_schedule::FullSchedule),
+    FullScheduleLoaded(&'static full_schedule::FullSchedule),
     SeriesPoster(SeriesPosterIndexedMessage<SeriesPosterMessage>),
 }
 

--- a/src/gui/tabs/discover_tab/mod.rs
+++ b/src/gui/tabs/discover_tab/mod.rs
@@ -340,7 +340,7 @@ mod full_schedule_posters {
 
     #[derive(Debug, Clone)]
     pub enum Message {
-        FullScheduleLoaded(caching::tv_schedule::full_schedule::FullSchedule),
+        FullScheduleLoaded(&'static caching::tv_schedule::full_schedule::FullSchedule),
         MonthlyNewPosters(SeriesPosterIndexedMessage<SeriesPosterMessage>),
         MonthlyReturningPosters(SeriesPosterIndexedMessage<SeriesPosterMessage>),
         PopularPosters(SeriesPosterIndexedMessage<SeriesPosterMessage>),


### PR DESCRIPTION
This PR improves `full-schedule episodes` (all upcoming episodes known by tvmaze that are used for multiple sections in the `discover page` and suggestion section in `series page`) by initialing them only once, preventing multiple downloads of the same episodes when being called in different parts of the program.