### PR TITLE
Add watchlist summary in watchlist page

### DIFF
--- a/src/gui/helpers.rs
+++ b/src/gui/helpers.rs
@@ -163,6 +163,20 @@ pub mod time {
         };
         (word, time_value)
     }
+
+    impl std::fmt::Display for SaneTime {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            let str = self
+                .get_time_plurized()
+                .into_iter()
+                .rev()
+                .fold(String::new(), |acc, (time_text, time_value)| {
+                    acc + &format!("{} {} ", time_value, time_text)
+                });
+
+            write!(f, "{}", str)
+        }
+    }
 }
 
 pub fn genres_with_pipes(genres: &[String]) -> String {

--- a/src/gui/series_page/series/data_widgets.rs
+++ b/src/gui/series_page/series/data_widgets.rs
@@ -221,11 +221,6 @@ pub fn next_episode_release_time_widget(
             helpers::time::SaneTime::new(
                 release_time.get_remaining_release_duration().num_minutes() as u32
             )
-            .get_time_plurized()
-            .into_iter()
-            .rev()
-            .fold(String::new(), |acc, (time_text, time_value)| acc
-                + &format!("{} {} ", time_value, time_text))
         ))
         .size(14);
 

--- a/src/gui/troxide_widget.rs
+++ b/src/gui/troxide_widget.rs
@@ -105,6 +105,10 @@ pub mod series_poster {
             self.hidden
         }
 
+        pub fn get_series_info(&self) -> &SeriesMainInformation {
+            &self.series_information
+        }
+
         /// Views the series poster widget
         ///
         /// This is the normal view of the poster, just having the image of the
@@ -286,15 +290,9 @@ pub mod series_poster {
             metadata = metadata.push(text(format!("{} episodes left", episodes_left)));
 
             if let Some(runtime) = self.series_information.average_runtime {
-                let time = helpers::time::SaneTime::new(runtime * episodes_left as u32)
-                    .get_time_plurized();
-                let watchtime: String = time
-                    .into_iter()
-                    .rev()
-                    .fold(String::new(), |acc, (time_text, time_value)| {
-                        acc + &format!("{} {} ", time_value, time_text)
-                    });
-                metadata = metadata.push(text(watchtime));
+                metadata = metadata.push(text(helpers::time::SaneTime::new(
+                    runtime * episodes_left as u32,
+                )));
             };
 
             content = content.push(metadata);


### PR DESCRIPTION
This PR adds `watchlist summary` in the `watchlist page`. 