### PR TITLE
Improve episode appearance

### DIFF
--- a/src/core/caching/episode_list.rs
+++ b/src/core/caching/episode_list.rs
@@ -134,9 +134,7 @@ impl EpisodeList {
     /// This method returns an optional bool as an episode my not have airstamp associated with it hence
     /// the method can not infer that information.
     pub fn is_episode_watchable(episode: &Episode) -> Option<bool> {
-        let airstamp = DateTime::parse_from_rfc3339(episode.airstamp.as_ref()?)
-            .unwrap()
-            .with_timezone(&Local);
+        let airstamp = episode.local_date_time().ok()?;
         let local_time = Utc::now().with_timezone(&Local);
         Some(airstamp <= local_time)
     }

--- a/src/core/caching/episode_list.rs
+++ b/src/core/caching/episode_list.rs
@@ -1,18 +1,14 @@
 use std::{collections::HashSet, io::ErrorKind};
 
-use crate::core::{
-    api::tv_maze::{
-        deserialize_json,
-        episodes_information::{get_episode_list, Episode},
-        ApiError,
-    },
-    caching::CACHER,
-    database,
-};
-use chrono::{DateTime, Datelike, Duration, Local, Timelike, Utc};
+use chrono::{Local, Utc};
 use tracing::info;
 
 use super::{read_cache, write_cache, CacheFilePath};
+use crate::core::api::tv_maze::deserialize_json;
+pub use crate::core::api::tv_maze::episodes_information::EpisodeReleaseTime;
+use crate::core::api::tv_maze::episodes_information::{get_episode_list, Episode};
+use crate::core::api::tv_maze::ApiError;
+use crate::core::{caching::CACHER, database};
 
 #[derive(Clone, Debug)]
 pub struct EpisodeList {
@@ -167,9 +163,7 @@ impl EpisodeList {
     /// Returns the next episode to air and it's release time
     pub fn get_next_episode_to_air_and_time(&self) -> Option<(&Episode, EpisodeReleaseTime)> {
         let next_episode = self.get_next_episode_to_air()?;
-        let local_date_time = next_episode.local_date_time().ok()?;
-
-        let release_time = EpisodeReleaseTime::new(local_date_time);
+        let release_time = next_episode.episode_release_time().ok()?;
         Some((next_episode, release_time))
     }
 
@@ -217,47 +211,5 @@ impl TotalEpisodes {
     /// Retrieves all the watchable episodes
     pub fn get_all_watchable_episodes(&self) -> usize {
         self.all_watchable_episodes
-    }
-}
-
-#[derive(Debug, Clone, PartialEq, PartialOrd, Ord, Eq)]
-pub struct EpisodeReleaseTime {
-    release_time: DateTime<Local>,
-}
-
-impl EpisodeReleaseTime {
-    pub fn new(release_time: DateTime<Local>) -> Self {
-        Self { release_time }
-    }
-
-    pub fn get_remaining_release_duration(&self) -> Duration {
-        let local_time = Utc::now().with_timezone(&Local);
-        self.release_time - local_time
-    }
-
-    /// Returns the remaining full date and time for an episode to be released
-    pub fn get_full_release_date_and_time(&self) -> String {
-        /// appends zero the minute digit if it's below 10 for better display
-        fn append_zero(num: u32) -> String {
-            if num < 10 {
-                format!("0{num}")
-            } else {
-                format!("{num}")
-            }
-        }
-
-        let (is_pm, hour) = self.release_time.hour12();
-        let pm_am = if is_pm { "p.m." } else { "a.m." };
-
-        let minute = append_zero(self.release_time.minute());
-
-        format!(
-            "{} {} {}:{} {}",
-            self.release_time.date_naive(),
-            self.release_time.weekday(),
-            hour,
-            minute,
-            pm_am
-        )
     }
 }

--- a/src/gui/tabs/my_shows_tab/upcoming_releases_widget.rs
+++ b/src/gui/tabs/my_shows_tab/upcoming_releases_widget.rs
@@ -252,9 +252,7 @@ mod upcoming_poster {
                 episode_name,
             )));
 
-            metadata = metadata.push(text(
-                self.episode_release_time.get_full_release_date_and_time(),
-            ));
+            metadata = metadata.push(text(&self.episode_release_time));
 
             content = content.push(metadata);
 

--- a/src/gui/troxide_widget.rs
+++ b/src/gui/troxide_widget.rs
@@ -136,7 +136,8 @@ pub mod episode_widget {
                 PosterType::Season => (700_f32, 107_f32, 60_f32),
             };
 
-            let mut content = row!().padding(5).width(poster_width);
+            let mut content = row!().padding(5).spacing(5).width(poster_width);
+
             if let Some(image_bytes) = self.episode_image.clone() {
                 let image_handle = image::Handle::from_memory(image_bytes);
                 let image = image(image_handle).height(image_height);
@@ -145,15 +146,14 @@ pub mod episode_widget {
                 content = content.push(Space::new(image_width, image_height));
             };
 
-            let info = column!(
+            let episode_details = column!(
                 heading_widget(self.series_id, &self.episode_information, poster_type),
                 date_time_widget(&self.episode_information),
                 vertical_space(5),
                 summary_widget(&self.episode_information)
-            )
-            .padding(5);
+            );
 
-            let content = content.push(info);
+            let content = content.push(episode_details);
 
             let mut content = container(content);
 

--- a/src/gui/troxide_widget.rs
+++ b/src/gui/troxide_widget.rs
@@ -146,7 +146,7 @@ pub mod episode_widget {
 
             let info = column!(
                 heading_widget(self.series_id, &self.episode_information, poster_type),
-                airdate_widget(&self.episode_information),
+                date_time_widget(&self.episode_information),
                 vertical_space(5),
                 summary_widget(&self.episode_information)
             )
@@ -176,11 +176,15 @@ pub mod episode_widget {
         }
     }
 
-    fn airdate_widget(episode_information: &EpisodeInfo) -> Text<'static, Renderer> {
-        if let Some(airdate) = &episode_information.airdate {
-            text(format!("Air date: {}", airdate)).size(11)
+    fn date_time_widget(episode_information: &EpisodeInfo) -> Element<'_, Message, Renderer> {
+        if let Ok(release_time) = episode_information.episode_release_time() {
+            let prefix = match release_time.is_future() {
+                true => "Airing on",
+                false => "Aired on",
+            };
+            text(format!("{} {}", prefix, release_time)).into()
         } else {
-            text("")
+            Space::new(0, 0).into()
         }
     }
 

--- a/src/gui/troxide_widget.rs
+++ b/src/gui/troxide_widget.rs
@@ -6,11 +6,12 @@ pub mod episode_widget {
     };
     use bytes::Bytes;
     use iced::{
+        font::Weight,
         widget::{
             button, checkbox, column, container, horizontal_space, image, row, svg, text,
             vertical_space, Row, Space, Text,
         },
-        Command, Element, Length, Renderer,
+        Command, Element, Font, Length, Renderer,
     };
 
     #[derive(Clone, Debug)]
@@ -222,16 +223,21 @@ pub mod episode_widget {
                     .into()
             }
         };
+
         row![
-            if let Some(episode_number) = episode_information.number {
-                text(season_episode_str_gen(
-                    episode_information.season,
-                    episode_number,
-                ))
-            } else {
-                text("")
-            },
-            text(&episode_information.name).size(13),
+            text(format!(
+                "{} {}",
+                episode_information
+                    .number
+                    .map(|number| season_episode_str_gen(episode_information.season, number))
+                    .unwrap_or_default(),
+                episode_information.name
+            ))
+            .font(Font {
+                weight: Weight::Bold,
+                ..Default::default()
+            })
+            .style(styles::text_styles::accent_color_theme()),
             horizontal_space(Length::Fill),
             mark_watched_widget
         ]


### PR DESCRIPTION
This PR improves episode appearance by making the episode title bold with accent color and provide more useful airtime by including the day that the episode aired/air and it's time with local time awareness.