### PR TITLE
Improve program update check

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3745,6 +3745,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "semver"
+version = "1.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "836fa6a3e1e547f9a2c4040802ec865b5d85f4014efe00555d7090a3dcaa1090"
+
+[[package]]
 name = "serde"
 version = "1.0.189"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3832,6 +3838,7 @@ dependencies = [
  "reqwest",
  "rfd",
  "rust_iso3166",
+ "semver",
  "serde",
  "serde_json",
  "sha2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,6 +41,7 @@ webbrowser = "0.8.12"
 notify-rust = "4.9.0"
 notify = "6.1.1"
 num-traits = "0.2.17"
+semver = "1.0.20"
 
 [build-dependencies]
 built = { version = "0.7.1", features = ["git2", "chrono"] }

--- a/src/core/api/crates.rs
+++ b/src/core/api/crates.rs
@@ -24,7 +24,11 @@ impl Crate {
     }
 
     pub fn is_up_to_date(&self) -> bool {
-        self.newest_version == env!("CARGO_PKG_VERSION")
+        let crates_io_version =
+            semver::Version::parse(&self.newest_version).expect("parse version");
+        let program_version =
+            semver::Version::parse(env!("CARGO_PKG_VERSION")).expect("parse version");
+        program_version >= crates_io_version
     }
 
     pub fn updated_at(&self) -> Result<chrono::NaiveDate, chrono::ParseError> {


### PR DESCRIPTION
This PR improves program update check by making use of `semver` crate to compare the program version and the one in `crates.io`.