### PR TITLE
Add placeholder for empty images in episode posters

### DIFF
--- a/assets/logos/series-troxide-grayscaled.svg
+++ b/assets/logos/series-troxide-grayscaled.svg
@@ -1,0 +1,358 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="102mm"
+   height="102mm"
+   viewBox="0 0 102 102"
+   version="1.1"
+   id="svg1"
+   inkscape:version="1.3 (0e150ed6c4, 2023-07-21)"
+   sodipodi:docname="series-troxide-grayscaled.svg"
+   inkscape:export-filename="series-troxide.png"
+   inkscape:export-xdpi="179.29411"
+   inkscape:export-ydpi="179.29411"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <sodipodi:namedview
+     id="namedview1"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     inkscape:document-units="mm"
+     inkscape:zoom="1.0721378"
+     inkscape:cx="200.53392"
+     inkscape:cy="226.64997"
+     inkscape:window-width="1920"
+     inkscape:window-height="1050"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="layer2" />
+  <defs
+     id="defs1">
+    <inkscape:path-effect
+       effect="skeletal"
+       id="path-effect11"
+       is_visible="true"
+       lpeversion="1"
+       pattern="M 0,4.9921382 C 0,2.2364779 2.2364779,0 4.9921382,0 c 2.7556604,0 4.9921383,2.2364779 4.9921383,4.9921382 0,2.7556604 -2.2364779,4.9921383 -4.9921383,4.9921383 C 2.2364779,9.9842765 0,7.7477986 0,4.9921382 Z"
+       copytype="single_stretched"
+       prop_scale="0.1221914"
+       scale_y_rel="false"
+       spacing="0"
+       normal_offset="0"
+       tang_offset="0"
+       prop_units="false"
+       vertical_pattern="false"
+       hide_knot="false"
+       fuse_tolerance="0" />
+    <inkscape:path-effect
+       effect="skeletal"
+       id="path-effect11-7"
+       is_visible="true"
+       lpeversion="1"
+       pattern="M 0,4.9921382 C 0,2.2364779 2.2364779,0 4.9921382,0 c 2.7556604,0 4.9921383,2.2364779 4.9921383,4.9921382 0,2.7556604 -2.2364779,4.9921383 -4.9921383,4.9921383 C 2.2364779,9.9842765 0,7.7477986 0,4.9921382 Z"
+       copytype="single_stretched"
+       prop_scale="0.3067289"
+       scale_y_rel="false"
+       spacing="0"
+       normal_offset="0"
+       tang_offset="0"
+       prop_units="false"
+       vertical_pattern="false"
+       hide_knot="false"
+       fuse_tolerance="0" />
+    <filter
+       style="color-interpolation-filters:sRGB;"
+       inkscape:label="Greyscale"
+       id="filter1"
+       x="-0.0048842978"
+       y="-0.020152501"
+       width="1.0097686"
+       height="1.040305">
+      <feColorMatrix
+         values="0.21 0.72 0.072 0 0 0.21 0.72 0.072 0 0 0.21 0.72 0.072 0 0 0 0 0 1 0 "
+         id="feColorMatrix1" />
+    </filter>
+    <filter
+       style="color-interpolation-filters:sRGB;"
+       inkscape:label="Greyscale"
+       id="filter2"
+       x="-0.0016690075"
+       y="-0.0021196497"
+       width="1.003338"
+       height="1.0042393">
+      <feColorMatrix
+         values="0.21 0.72 0.072 0 0 0.21 0.72 0.072 0 0 0.21 0.72 0.072 0 0 0 0 0 1 0 "
+         id="feColorMatrix2" />
+    </filter>
+    <filter
+       style="color-interpolation-filters:sRGB;"
+       inkscape:label="Greyscale"
+       id="filter3"
+       x="-0.065933539"
+       y="-0.006232607"
+       width="1.1318671"
+       height="1.0124652">
+      <feColorMatrix
+         values="0.21 0.72 0.072 0 0 0.21 0.72 0.072 0 0 0.21 0.72 0.072 0 0 0 0 0 1 0 "
+         id="feColorMatrix3" />
+    </filter>
+    <filter
+       style="color-interpolation-filters:sRGB;"
+       inkscape:label="Greyscale"
+       id="filter4"
+       x="-0.15069796"
+       y="-0.011876292"
+       width="1.3013959"
+       height="1.0237526">
+      <feColorMatrix
+         values="0.21 0.72 0.072 0 0 0.21 0.72 0.072 0 0 0.21 0.72 0.072 0 0 0 0 0 1 0 "
+         id="feColorMatrix4" />
+    </filter>
+    <filter
+       style="color-interpolation-filters:sRGB;"
+       inkscape:label="Greyscale"
+       id="filter5"
+       x="-0.076066325"
+       y="-0.12755149"
+       width="1.1521326"
+       height="1.255103">
+      <feColorMatrix
+         values="0.21 0.72 0.072 0 0 0.21 0.72 0.072 0 0 0.21 0.72 0.072 0 0 0 0 0 1 0 "
+         id="feColorMatrix5" />
+    </filter>
+    <filter
+       style="color-interpolation-filters:sRGB;"
+       inkscape:label="Greyscale"
+       id="filter6"
+       x="-0.065933539"
+       y="-0.006232607"
+       width="1.1318671"
+       height="1.0124652">
+      <feColorMatrix
+         values="0.21 0.72 0.072 0 0 0.21 0.72 0.072 0 0 0.21 0.72 0.072 0 0 0 0 0 1 0 "
+         id="feColorMatrix6" />
+    </filter>
+    <filter
+       style="color-interpolation-filters:sRGB;"
+       inkscape:label="Greyscale"
+       id="filter7"
+       x="-0.15069796"
+       y="-0.011876292"
+       width="1.3013959"
+       height="1.0237526">
+      <feColorMatrix
+         values="0.21 0.72 0.072 0 0 0.21 0.72 0.072 0 0 0.21 0.72 0.072 0 0 0 0 0 1 0 "
+         id="feColorMatrix7" />
+    </filter>
+    <filter
+       style="color-interpolation-filters:sRGB;"
+       inkscape:label="Greyscale"
+       id="filter8"
+       x="-0.076066325"
+       y="-0.12755149"
+       width="1.1521326"
+       height="1.255103">
+      <feColorMatrix
+         values="0.21 0.72 0.072 0 0 0.21 0.72 0.072 0 0 0.21 0.72 0.072 0 0 0 0 0 1 0 "
+         id="feColorMatrix8" />
+    </filter>
+    <filter
+       style="color-interpolation-filters:sRGB;"
+       inkscape:label="Greyscale"
+       id="filter9"
+       x="-0.0022780034"
+       y="-0.0029980985"
+       width="1.004556"
+       height="1.0059962">
+      <feColorMatrix
+         values="0.21 0.72 0.072 0 0 0.21 0.72 0.072 0 0 0.21 0.72 0.072 0 0 0 0 0 1 0 "
+         id="feColorMatrix9" />
+    </filter>
+    <filter
+       style="color-interpolation-filters:sRGB;"
+       inkscape:label="Greyscale"
+       id="filter10"
+       x="-0.0022317351"
+       y="-0.0030602464"
+       width="1.0044635"
+       height="1.0061205">
+      <feColorMatrix
+         values="0.21 0.72 0.072 0 0 0.21 0.72 0.072 0 0 0.21 0.72 0.072 0 0 0 0 0 1 0 "
+         id="feColorMatrix10" />
+    </filter>
+    <filter
+       style="color-interpolation-filters:sRGB;"
+       inkscape:label="Greyscale"
+       id="filter11"
+       x="0"
+       y="0"
+       width="1"
+       height="1">
+      <feColorMatrix
+         values="0.21 0.72 0.072 0 0 0.21 0.72 0.072 0 0 0.21 0.72 0.072 0 0 0 0 0 1 0 "
+         id="feColorMatrix11" />
+    </filter>
+    <filter
+       style="color-interpolation-filters:sRGB;"
+       inkscape:label="Greyscale"
+       id="filter12"
+       x="-0.022712895"
+       y="-0.013245713"
+       width="1.0454258"
+       height="1.0264914">
+      <feColorMatrix
+         values="0.21 0.72 0.072 0 0 0.21 0.72 0.072 0 0 0.21 0.72 0.072 0 0 0 0 0 1 0 "
+         id="feColorMatrix12" />
+    </filter>
+    <filter
+       style="color-interpolation-filters:sRGB;"
+       inkscape:label="Greyscale"
+       id="filter13"
+       x="-0.023062649"
+       y="-0.013044861"
+       width="1.0461253"
+       height="1.0260897">
+      <feColorMatrix
+         values="0.21 0.72 0.072 0 0 0.21 0.72 0.072 0 0 0.21 0.72 0.072 0 0 0 0 0 1 0 "
+         id="feColorMatrix13" />
+    </filter>
+  </defs>
+  <g
+     inkscape:groupmode="layer"
+     id="layer7"
+     inkscape:label="stand"
+     style="display:inline">
+    <ellipse
+       style="fill:#b3b3b3;fill-opacity:1;stroke:#000000;stroke-width:0.362231;filter:url(#filter1)"
+       id="path10"
+       cx="53.734413"
+       cy="88.932671"
+       rx="18.540586"
+       ry="4.4936233" />
+  </g>
+  <g
+     inkscape:groupmode="layer"
+     id="layer2"
+     inkscape:label="body">
+    <ellipse
+       style="fill:#8f6593;fill-opacity:1;stroke:#000000;stroke-width:0.264583;filter:url(#filter2)"
+       id="path2"
+       cx="53.173447"
+       cy="59.926918"
+       rx="39.631786"
+       ry="31.20598" />
+  </g>
+  <g
+     inkscape:groupmode="layer"
+     id="layer6"
+     inkscape:label="right-antenna"
+     transform="rotate(26.626716,63.663425,91.348082)"
+     style="display:inline">
+    <rect
+       style="fill:#b3b3b3;stroke:#000000;stroke-width:0.264583;filter:url(#filter3)"
+       id="rect5"
+       width="2.0064371"
+       height="21.225708"
+       x="27.764742"
+       y="25.941788" />
+    <rect
+       style="fill:#b3b3b3;stroke:#000000;stroke-width:0.264583;filter:url(#filter4)"
+       id="rect6"
+       width="0.87785858"
+       height="11.139125"
+       x="28.320299"
+       y="14.803336" />
+    <rect
+       style="fill:#b3b3b3;stroke:#000000;stroke-width:0.264583;filter:url(#filter5)"
+       id="rect7"
+       width="1.7391598"
+       height="1.0371615"
+       x="27.84543"
+       y="13.598304" />
+  </g>
+  <g
+     inkscape:groupmode="layer"
+     id="g10"
+     inkscape:label="left-antenna"
+     transform="matrix(0.78455439,-0.39703989,0.36681053,0.84921059,-42.959282,47.424815)"
+     style="display:inline">
+    <rect
+       style="fill:#b3b3b3;stroke:#000000;stroke-width:0.264583;filter:url(#filter6)"
+       id="rect8"
+       width="2.0064371"
+       height="21.225708"
+       x="88.477699"
+       y="6.2007856" />
+    <rect
+       style="fill:#b3b3b3;stroke:#000000;stroke-width:0.264583;filter:url(#filter7)"
+       id="rect9"
+       width="0.87785858"
+       height="11.139125"
+       x="89.033257"
+       y="-4.9376626" />
+    <rect
+       style="fill:#b3b3b3;stroke:#000000;stroke-width:0.264583;filter:url(#filter8)"
+       id="rect10"
+       width="1.7391598"
+       height="1.0371615"
+       x="88.558388"
+       y="-6.142695" />
+  </g>
+  <g
+     inkscape:label="screen"
+     inkscape:groupmode="layer"
+     id="layer1"
+     style="display:inline">
+    <ellipse
+       style="fill:#000000;fill-opacity:1;stroke:#000000;stroke-width:0.264583;filter:url(#filter9)"
+       id="path3"
+       cx="38.638641"
+       cy="60.920479"
+       rx="29.03672"
+       ry="22.062567" />
+    <ellipse
+       style="fill:#666666;stroke:#000000;stroke-width:0.247975;filter:url(#filter10)"
+       id="ellipse3"
+       cx="38.034561"
+       cy="60.978752"
+       rx="27.778275"
+       ry="20.257765" />
+    <path
+       style="fill:#b3b3b3;fill-opacity:1;stroke:none;stroke-width:0.264583;filter:url(#filter11)"
+       d="m 34.697799,122.55314 c 0.277092,0.0538 -0.05341,3.00133 -0.74596,6.92662 0,0 0,0 0,0 -0.04439,0.74646 -0.06923,1.53363 -0.05329,2.3357 0.02397,1.20617 0.137361,2.30304 0.342942,3.32934 0,0 0,0 0,0 0.650331,3.24477 2.351374,5.07761 2.173874,5.26291 -0.149009,0.15555 -2.358397,-1.29697 -3.279062,-5.0143 0,0 0,0 0,0 -0.273954,-1.1057 -0.427574,-2.30419 -0.452319,-3.59435 -0.01651,-0.861 0.02565,-1.69455 0.102105,-2.47787 0,0 0,0 0,0 0.836903,-3.95488 1.634444,-6.82186 1.911713,-6.76805 z"
+       id="path11"
+       inkscape:path-effect="#path-effect11"
+       inkscape:original-d="m 34.697819,122.55308 c 0,0 -4.11305,12.26932 1.717536,17.85462"
+       sodipodi:nodetypes="cc"
+       transform="matrix(0.97122863,0.08809259,-0.09412623,0.90897134,-6.1653708,-61.757664)" />
+  </g>
+  <g
+     inkscape:groupmode="layer"
+     id="layer3"
+     inkscape:label="knob"
+     style="display:inline">
+    <ellipse
+       style="fill:#000000;stroke:#000000;stroke-width:0.264583;filter:url(#filter12)"
+       id="ellipse10"
+       cx="84.35968"
+       cy="58.413628"
+       rx="2.9122553"
+       ry="4.9937477" />
+    <ellipse
+       style="fill:#b3b3b3;stroke:#000000;stroke-width:0.22029;filter:url(#filter13)"
+       id="path4"
+       cx="84.715714"
+       cy="58.418968"
+       rx="2.3879521"
+       ry="4.2217774" />
+  </g>
+</svg>

--- a/src/gui/assets.rs
+++ b/src/gui/assets.rs
@@ -22,6 +22,8 @@ pub mod icons {
     pub static GITHUB_ICON: &[u8] = include_bytes!("../../assets/icons/github.svg");
     pub static TRAKT_ICON_RED: &[u8] = include_bytes!("../../assets/logos/trakt-icon-red.svg");
     pub static SERIES_TROXIDE_ICON: &[u8] = include_bytes!("../../assets/logos/series-troxide.svg");
+    pub static SERIES_TROXIDE_GRAY_SCALED_ICON: &[u8] =
+        include_bytes!("../../assets/logos/series-troxide-grayscaled.svg");
 }
 
 pub mod fonts {

--- a/src/gui/helpers.rs
+++ b/src/gui/helpers.rs
@@ -22,6 +22,19 @@ pub fn season_episode_str_gen(season_number: u32, episode_number: u32) -> String
     )
 }
 
+pub fn genres_with_pipes(genres: &[String]) -> String {
+    let mut genres_string = String::new();
+
+    let mut series_result_iter = genres.iter().peekable();
+    while let Some(genre) = series_result_iter.next() {
+        genres_string.push_str(genre);
+        if series_result_iter.peek().is_some() {
+            genres_string.push_str(" | ");
+        }
+    }
+    genres_string
+}
+
 pub mod time {
     //! Time related helpers
     use chrono::Duration;
@@ -157,15 +170,14 @@ pub mod time {
     }
 }
 
-pub fn genres_with_pipes(genres: &[String]) -> String {
-    let mut genres_string = String::new();
+pub mod empty_image {
+    use crate::gui::assets::icons::SERIES_TROXIDE_GRAY_SCALED_ICON;
 
-    let mut series_result_iter = genres.iter().peekable();
-    while let Some(genre) = series_result_iter.next() {
-        genres_string.push_str(genre);
-        if series_result_iter.peek().is_some() {
-            genres_string.push_str(" | ");
-        }
+    use iced::widget::{svg, Svg};
+
+    /// Placeholder for an empty image
+    pub fn empty_image() -> Svg {
+        let icon_handle = svg::Handle::from_memory(SERIES_TROXIDE_GRAY_SCALED_ICON);
+        svg(icon_handle)
     }
-    genres_string
 }

--- a/src/gui/series_page/series/cast_widget.rs
+++ b/src/gui/series_page/series/cast_widget.rs
@@ -247,6 +247,8 @@ mod cast_poster {
         pub fn view(&self) -> Element<'_, IndexedMessage<Message>, Renderer> {
             let mut content = Row::new().spacing(10);
 
+            let empty_image = helpers::empty_image::empty_image().width(100).height(140);
+
             match self.current_display_image {
                 DisplayImage::Person => {
                     if let Some(image_bytes) = self.person_image.clone() {
@@ -255,7 +257,7 @@ mod cast_poster {
                         let image = image(image_handle).width(100);
                         content = content.push(image);
                     } else {
-                        content = content.push(Space::new(100, 140));
+                        content = content.push(empty_image);
                     };
                 }
                 DisplayImage::Character => {
@@ -265,7 +267,7 @@ mod cast_poster {
                         let image = image(image_handle).width(100);
                         content = content.push(image);
                     } else {
-                        content = content.push(Space::new(100, 140));
+                        content = content.push(empty_image);
                     };
                 }
             }

--- a/src/gui/series_page/series/mod.rs
+++ b/src/gui/series_page/series/mod.rs
@@ -6,7 +6,7 @@ use crate::core::api::tv_maze::Image;
 use crate::core::caching::episode_list::EpisodeReleaseTime;
 use crate::core::{caching, database};
 use crate::gui::assets::icons::{PATCH_PLUS, PATCH_PLUS_FILL};
-use crate::gui::styles;
+use crate::gui::{helpers, styles};
 
 use bytes::Bytes;
 use cast_widget::{CastWidget, Message as CastWidgetMessage};
@@ -43,7 +43,7 @@ pub fn series_metadata<'a>(
 
         main_info = main_info.push(image);
     } else {
-        main_info = main_info.push(Space::new(180, 253));
+        main_info = main_info.push(helpers::empty_image::empty_image().width(180).height(253));
     };
 
     let mut series_data_grid = Grid::with_columns(2);

--- a/src/gui/tabs/my_shows_tab/upcoming_releases_widget.rs
+++ b/src/gui/tabs/my_shows_tab/upcoming_releases_widget.rs
@@ -161,7 +161,7 @@ mod upcoming_poster {
     use crate::gui::troxide_widget::series_poster::{GenericPoster, GenericPosterMessage};
 
     use iced::widget::{
-        column, container, horizontal_space, image, mouse_area, row, text, vertical_space, Space,
+        column, container, horizontal_space, image, mouse_area, row, text, vertical_space,
     };
     use iced::{Command, Element, Length, Renderer};
 
@@ -226,7 +226,7 @@ mod upcoming_poster {
                 let image = image(image_handle).width(100);
                 content = content.push(image);
             } else {
-                content = content.push(Space::new(100, 140));
+                content = content.push(helpers::empty_image::empty_image().width(100).height(140));
             };
 
             let mut metadata = column!().spacing(5);

--- a/src/gui/tabs/statistics_tab/mini_widgets.rs
+++ b/src/gui/tabs/statistics_tab/mini_widgets.rs
@@ -178,7 +178,7 @@ pub fn genre_stats(series_infos: Vec<&SeriesMainInformation>) -> Element<'_, Mes
 pub mod series_banner {
     use std::sync::mpsc;
 
-    use iced::widget::{column, container, image, mouse_area, row, text, Row, Space};
+    use iced::widget::{column, container, image, mouse_area, row, text, Row};
     use iced::{Alignment, Command, Element, Length, Renderer};
 
     use crate::core::{api::tv_maze::series_information::SeriesMainInformation, database};
@@ -290,7 +290,10 @@ pub mod series_banner {
                     let image_handle = image::Handle::from_memory(image_bytes.clone());
                     image(image_handle).height(100).into()
                 } else {
-                    Space::new(71, 100).into()
+                    helpers::empty_image::empty_image()
+                        .width(71)
+                        .height(100)
+                        .into()
                 };
 
             let content = column![text(series_name), metadata]

--- a/src/gui/troxide_widget.rs
+++ b/src/gui/troxide_widget.rs
@@ -411,7 +411,10 @@ pub mod series_poster {
                     let image_handle = image::Handle::from_memory(image_bytes.clone());
                     image(image_handle).height(image_height).into()
                 } else {
-                    Space::new(image_height as f32 / 1.4, image_height).into()
+                    helpers::empty_image::empty_image()
+                        .width(image_height as f32 / 1.4)
+                        .height(image_height)
+                        .into()
                 }
             };
 

--- a/src/gui/troxide_widget.rs
+++ b/src/gui/troxide_widget.rs
@@ -2,7 +2,11 @@ pub mod episode_widget {
     pub use crate::gui::message::IndexedMessage;
     use crate::{
         core::{api::tv_maze::episodes_information::Episode as EpisodeInfo, caching, database},
-        gui::{assets::icons::EYE_FILL, helpers::season_episode_str_gen, styles},
+        gui::{
+            assets::icons::EYE_FILL,
+            helpers::{self, season_episode_str_gen},
+            styles,
+        },
     };
     use bytes::Bytes;
     use iced::{
@@ -143,7 +147,11 @@ pub mod episode_widget {
                 let image = image(image_handle).height(image_height);
                 content = content.push(image);
             } else {
-                content = content.push(Space::new(image_width, image_height));
+                content = content.push(
+                    helpers::empty_image::empty_image()
+                        .width(image_width)
+                        .height(image_height),
+                );
             };
 
             let episode_details = column!(

--- a/src/gui/troxide_widget.rs
+++ b/src/gui/troxide_widget.rs
@@ -1,22 +1,18 @@
 pub mod episode_widget {
+    use crate::core::{
+        api::tv_maze::episodes_information::Episode as EpisodeInfo, caching, database,
+    };
+    use crate::gui::assets::icons::EYE_FILL;
+    use crate::gui::helpers::{self, season_episode_str_gen};
     pub use crate::gui::message::IndexedMessage;
-    use crate::{
-        core::{api::tv_maze::episodes_information::Episode as EpisodeInfo, caching, database},
-        gui::{
-            assets::icons::EYE_FILL,
-            helpers::{self, season_episode_str_gen},
-            styles,
-        },
-    };
+    use crate::gui::styles;
     use bytes::Bytes;
-    use iced::{
-        font::Weight,
-        widget::{
-            button, checkbox, column, container, horizontal_space, image, row, svg, text,
-            vertical_space, Row, Space, Text,
-        },
-        Command, Element, Font, Length, Renderer,
+    use iced::font::Weight;
+    use iced::widget::{
+        button, checkbox, column, container, horizontal_space, image, row, svg, text,
+        vertical_space, Row, Space, Text,
     };
+    use iced::{Command, Element, Font, Length, Renderer};
 
     #[derive(Clone, Debug)]
     pub enum Message {


### PR DESCRIPTION
This PR adds grayscaled program logo to be placed in all episode posters that have no image/loading image.