### PR TITLE
Fix episode checkbox squish when episode name is too long

### DIFF
--- a/src/gui/troxide_widget.rs
+++ b/src/gui/troxide_widget.rs
@@ -9,8 +9,8 @@ pub mod episode_widget {
     use bytes::Bytes;
     use iced::font::Weight;
     use iced::widget::{
-        button, checkbox, column, container, horizontal_space, image, row, svg, text,
-        vertical_space, Row, Space, Text,
+        button, checkbox, column, container, image, row, svg, text, vertical_space, Row, Space,
+        Text,
     };
     use iced::{Command, Element, Font, Length, Renderer};
 
@@ -241,8 +241,8 @@ pub mod episode_widget {
                 weight: Weight::Bold,
                 ..Default::default()
             })
-            .style(styles::text_styles::accent_color_theme()),
-            horizontal_space(Length::Fill),
+            .style(styles::text_styles::accent_color_theme())
+            .width(Length::FillPortion(10)),
             mark_watched_widget
         ]
         .spacing(5)


### PR DESCRIPTION
This PR fixes the episode tracking checkbox being squished when the episode name is too long as both of them are in the same row.