### PR TITLE
Add custom program data paths

### DIFF
--- a/src/core/api/trakt/mod.rs
+++ b/src/core/api/trakt/mod.rs
@@ -213,12 +213,12 @@ pub mod user_credentials {
     use std::env::VarError;
 
     use chrono::Local;
-    use directories::ProjectDirs;
     use serde::{Deserialize, Serialize};
     use thiserror::Error;
     use tokio::fs;
 
     use super::{authenication::TokenResponse, user_settings::UserSettings, ApiError};
+    use crate::core::paths;
 
     const CREDENTIALS_FILENAME: &str = "credentials";
 
@@ -357,8 +357,8 @@ pub mod user_credentials {
 
         /// Get the filepath of the credentials file
         fn credentials_filepath() -> Option<std::path::PathBuf> {
-            ProjectDirs::from("", "", env!("CARGO_PKG_NAME")).map(|proj_dir| {
-                let mut credentials_filepath = std::path::PathBuf::from(&proj_dir.data_dir());
+            paths::PATHS.get().map(|paths| {
+                let mut credentials_filepath = paths.get_data_dir_path().to_path_buf();
                 credentials_filepath.push(CREDENTIALS_FILENAME);
                 credentials_filepath
             })

--- a/src/core/api/trakt/mod.rs
+++ b/src/core/api/trakt/mod.rs
@@ -357,11 +357,14 @@ pub mod user_credentials {
 
         /// Get the filepath of the credentials file
         fn credentials_filepath() -> Option<std::path::PathBuf> {
-            paths::PATHS.get().map(|paths| {
-                let mut credentials_filepath = paths.get_data_dir_path().to_path_buf();
-                credentials_filepath.push(CREDENTIALS_FILENAME);
-                credentials_filepath
-            })
+            paths::PATHS
+                .read()
+                .map(|paths| {
+                    let mut credentials_filepath = paths.get_data_dir_path().to_path_buf();
+                    credentials_filepath.push(CREDENTIALS_FILENAME);
+                    credentials_filepath
+                })
+                .ok()
         }
 
         /// Save the credentials to the filesystem

--- a/src/core/caching.rs
+++ b/src/core/caching.rs
@@ -77,8 +77,8 @@ pub struct Cacher {
 impl Cacher {
     pub fn init() -> Self {
         let cache_path = paths::PATHS
-            .get()
-            .expect("paths should be initialized")
+            .read()
+            .expect("failed to read paths")
             .get_cache_dir_path()
             .to_path_buf();
 

--- a/src/core/caching.rs
+++ b/src/core/caching.rs
@@ -33,7 +33,7 @@ use crate::core::api::tv_maze::{self, deserialize_json};
 
 use super::api::tv_maze::{series_information::SeriesMainInformation, ApiError};
 pub use super::api::tv_maze::{ImageType, OriginalType};
-use directories::ProjectDirs;
+use super::paths;
 use lazy_static::lazy_static;
 use tokio::fs;
 use tracing::{error, info};
@@ -76,10 +76,14 @@ pub struct Cacher {
 
 impl Cacher {
     pub fn init() -> Self {
-        let proj_dir = ProjectDirs::from("", "", env!("CARGO_PKG_NAME"))
-            .expect("could not get the cache path");
+        let cache_path = paths::PATHS
+            .get()
+            .expect("paths should be initialized")
+            .get_cache_dir_path()
+            .to_path_buf();
 
-        let cache_path = path::PathBuf::from(&proj_dir.cache_dir());
+        info!("initializing cache at {}", cache_path.display());
+
         Self { cache_path }
     }
 

--- a/src/core/cli.rs
+++ b/src/core/cli.rs
@@ -1,28 +1,37 @@
 //! Series Troxide module for handling command-line arguments
 
-pub mod handle_cli {
+pub mod cli_handler {
     //! Handlers for command-line argument parsing
 
-    use crate::core::database;
+    use clap::Parser;
+    use std::process::exit;
 
     use super::cli_data::*;
+    use crate::core::database;
 
     /// Handles all the logic for the command line arguments
-    pub fn handle_cli(command: Command) -> anyhow::Result<()> {
-        match command {
-            Command::ImportData { file_path } => {
-                database::database_transfer::TransferData::blocking_import_to_db(file_path)?;
-                println!("data imported successfully!");
-                Ok(())
-            }
-            Command::ExportData {
-                file_path: path_to_data,
-            } => {
-                database::database_transfer::TransferData::blocking_export_from_db(path_to_data)?;
-                println!("data exported successfully!");
-                Ok(())
+    pub fn handle_cli() -> anyhow::Result<()> {
+        let cli = Cli::parse();
+
+        if let Some(command) = cli.command {
+            match command {
+                Command::ImportData { file_path } => {
+                    database::database_transfer::TransferData::blocking_import_to_db(file_path)?;
+                    println!("data imported successfully!");
+                    exit(0);
+                }
+                Command::ExportData {
+                    file_path: path_to_data,
+                } => {
+                    database::database_transfer::TransferData::blocking_export_from_db(
+                        path_to_data,
+                    )?;
+                    println!("data exported successfully!");
+                    exit(0);
+                }
             }
         }
+        Ok(())
     }
 }
 
@@ -30,11 +39,23 @@ pub mod cli_data {
     //! Data structures for command-line argument parsing
 
     use clap::{Parser, Subcommand};
-    use std::path;
+    use std::path::PathBuf;
 
     #[derive(Parser)]
     #[command(author, version, about)]
     pub struct Cli {
+        /// Custom cache folder path
+        #[clap(short = 'a', long)]
+        cache_folder: Option<PathBuf>,
+
+        /// Custom data folder path
+        #[clap(short, long)]
+        data_folder: Option<PathBuf>,
+
+        /// Custom config folder path
+        #[clap(short, long)]
+        config_folder: Option<PathBuf>,
+
         #[clap(subcommand)]
         pub command: Option<Command>,
     }
@@ -44,13 +65,13 @@ pub mod cli_data {
         /// Import series data
         ImportData {
             /// Import filepath
-            file_path: path::PathBuf,
+            file_path: PathBuf,
         },
 
         /// Export series data
         ExportData {
             /// Export filepath
-            file_path: path::PathBuf,
+            file_path: PathBuf,
         },
     }
 }

--- a/src/core/database.rs
+++ b/src/core/database.rs
@@ -24,8 +24,8 @@ pub struct Database {
 impl Database {
     fn init() -> Self {
         let mut database_path = paths::PATHS
-            .get()
-            .expect("paths should be initialized")
+            .read()
+            .expect("failed to read paths")
             .get_data_dir_path()
             .to_path_buf();
 

--- a/src/core/database.rs
+++ b/src/core/database.rs
@@ -1,4 +1,3 @@
-use directories::ProjectDirs;
 use lazy_static::lazy_static;
 use serde::{Deserialize, Serialize};
 use sled::Db;
@@ -9,6 +8,7 @@ use std::{
 use tracing::info;
 
 use super::{api::tv_maze::series_information::SeriesMainInformation, caching};
+use crate::core::paths;
 
 // The last digit represents the version of the database.
 const DATABASE_FOLDER_NAME: &str = "series-troxide-db-1";
@@ -23,17 +23,20 @@ pub struct Database {
 
 impl Database {
     fn init() -> Self {
-        info!("opening database");
-        if let Some(proj_dir) = ProjectDirs::from("", "", env!("CARGO_PKG_NAME")) {
-            let mut database_path = std::path::PathBuf::from(&proj_dir.data_dir());
-            database_path.push(DATABASE_FOLDER_NAME);
-            let db = sled::open(database_path).unwrap();
-            if !db.was_recovered() {
-                info!("created a fresh database as none was found");
-            }
-            return Self { db };
+        let mut database_path = paths::PATHS
+            .get()
+            .expect("paths should be initialized")
+            .get_data_dir_path()
+            .to_path_buf();
+
+        info!("initializing database at {}", database_path.display());
+
+        database_path.push(DATABASE_FOLDER_NAME);
+        let db = sled::open(database_path).unwrap();
+        if !db.was_recovered() {
+            info!("created a fresh database as none was found");
         }
-        panic!("could not get the path to database");
+        Self { db }
     }
 
     /// Adds the given series to the database.

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -3,5 +3,6 @@ pub mod caching;
 pub mod cli;
 pub mod database;
 pub mod notifications;
+pub mod paths;
 pub mod posters_hiding;
 pub mod settings_config;

--- a/src/core/notifications.rs
+++ b/src/core/notifications.rs
@@ -115,8 +115,8 @@ impl TroxideNotify {
             .unwrap();
 
         let mut config_file = paths::PATHS
-            .get()
-            .expect("paths should be initialized")
+            .read()
+            .expect("failed to read paths")
             .get_config_dir_path()
             .to_path_buf();
 

--- a/src/core/paths.rs
+++ b/src/core/paths.rs
@@ -1,19 +1,19 @@
 use std::borrow::Cow;
 use std::path::PathBuf;
-use std::sync::OnceLock;
+use std::sync::RwLock;
 
 use directories::ProjectDirs;
 use lazy_static::lazy_static;
 
 lazy_static! {
-    pub static ref PATHS: OnceLock<Paths> = OnceLock::new();
+    pub static ref PATHS: RwLock<Paths> = RwLock::new(Paths::default());
 }
 
 /// Various Data paths for the program
 ///
 /// Stores custom paths, while providing platform specific paths
 /// when no custom one(s) provided
-#[derive(Debug, Default)]
+#[derive(Debug, Default, Clone)]
 pub struct Paths {
     custom_data_dir_path: Option<PathBuf>,
     custom_config_dir_path: Option<PathBuf>,

--- a/src/core/paths.rs
+++ b/src/core/paths.rs
@@ -1,0 +1,63 @@
+use std::borrow::Cow;
+use std::path::PathBuf;
+use std::sync::OnceLock;
+
+use directories::ProjectDirs;
+use lazy_static::lazy_static;
+
+lazy_static! {
+    pub static ref PATHS: OnceLock<Paths> = OnceLock::new();
+}
+
+/// Various Data paths for the program
+///
+/// Stores custom paths, while providing platform specific paths
+/// when no custom one(s) provided
+#[derive(Debug, Default)]
+pub struct Paths {
+    custom_data_dir_path: Option<PathBuf>,
+    custom_config_dir_path: Option<PathBuf>,
+    custom_cache_dir_path: Option<PathBuf>,
+}
+
+impl Paths {
+    fn project_dir() -> ProjectDirs {
+        ProjectDirs::from("", "", env!("CARGO_PKG_NAME")).expect("could not get the program paths")
+    }
+
+    pub fn get_data_dir_path(&self) -> Cow<PathBuf> {
+        if let Some(data_path) = &self.custom_data_dir_path {
+            Cow::Borrowed(data_path)
+        } else {
+            Cow::Owned(std::path::PathBuf::from(&Self::project_dir().data_dir()))
+        }
+    }
+
+    pub fn get_config_dir_path(&self) -> Cow<PathBuf> {
+        if let Some(config_path) = &self.custom_config_dir_path {
+            Cow::Borrowed(config_path)
+        } else {
+            Cow::Owned(std::path::PathBuf::from(&Self::project_dir().config_dir()))
+        }
+    }
+
+    pub fn get_cache_dir_path(&self) -> Cow<PathBuf> {
+        if let Some(cache_path) = &self.custom_cache_dir_path {
+            Cow::Borrowed(cache_path)
+        } else {
+            Cow::Owned(std::path::PathBuf::from(&Self::project_dir().cache_dir()))
+        }
+    }
+
+    pub fn set_data_dir_path(&mut self, data_dir_path: PathBuf) {
+        self.custom_data_dir_path = Some(data_dir_path)
+    }
+
+    pub fn set_config_dir_path(&mut self, config_dir_path: PathBuf) {
+        self.custom_config_dir_path = Some(config_dir_path)
+    }
+
+    pub fn set_cache_dir_path(&mut self, cache_dir_path: PathBuf) {
+        self.custom_cache_dir_path = Some(cache_dir_path)
+    }
+}

--- a/src/core/posters_hiding.rs
+++ b/src/core/posters_hiding.rs
@@ -3,12 +3,13 @@
 use std::collections::HashSet;
 use std::path;
 
-use directories::ProjectDirs;
 use indexmap::IndexMap;
 use lazy_static::lazy_static;
 use tokio::fs;
 use tokio::sync::RwLock;
 use tracing::{info, warn};
+
+use super::paths;
 
 const HIDDEN_SERIES_FILENAME: &str = "hidden-series";
 
@@ -25,10 +26,12 @@ pub struct HiddenSeries {
 
 impl HiddenSeries {
     fn new() -> Self {
-        let proj_dirs = ProjectDirs::from("", "", env!("CARGO_PKG_NAME"))
-            .expect("could not get the hidden series filepath");
+        let mut hidden_series_filepath = paths::PATHS
+            .get()
+            .expect("paths should be initialized")
+            .get_config_dir_path()
+            .to_path_buf();
 
-        let mut hidden_series_filepath = std::path::PathBuf::from(proj_dirs.config_dir());
         hidden_series_filepath.push(HIDDEN_SERIES_FILENAME);
 
         Self {

--- a/src/core/posters_hiding.rs
+++ b/src/core/posters_hiding.rs
@@ -27,8 +27,8 @@ pub struct HiddenSeries {
 impl HiddenSeries {
     fn new() -> Self {
         let mut hidden_series_filepath = paths::PATHS
-            .get()
-            .expect("paths should be initialized")
+            .read()
+            .expect("failed to read paths")
             .get_config_dir_path()
             .to_path_buf();
 

--- a/src/core/settings_config.rs
+++ b/src/core/settings_config.rs
@@ -3,10 +3,11 @@ use std::{
     sync::{Arc, RwLock},
 };
 
-use directories::ProjectDirs;
 use lazy_static::lazy_static;
 use serde::{Deserialize, Serialize};
 use tracing::{error, info, warn};
+
+use crate::core::paths;
 
 #[derive(Clone, Default, Debug, Serialize, Deserialize, Eq, PartialEq)]
 pub enum Theme {
@@ -129,69 +130,69 @@ impl Default for Settings {
 pub const CONFIG_FILE_NAME: &str = "config.toml";
 
 fn load_config() -> Config {
-    if let Some(proj_dirs) = ProjectDirs::from("", "", env!("CARGO_PKG_NAME")) {
-        let config_directory = std::path::PathBuf::from(proj_dirs.config_dir());
-        let mut config_file = config_directory.clone();
-        config_file.push(CONFIG_FILE_NAME);
+    let config_directory = paths::PATHS
+        .get()
+        .expect("paths should be initialized")
+        .get_config_dir_path()
+        .to_path_buf();
 
-        info!("loading config file at: '{}'", config_file.display());
+    let mut config_file = config_directory.clone();
+    config_file.push(CONFIG_FILE_NAME);
 
-        let file_contents = match std::fs::read_to_string(&config_file) {
-            Ok(file_contents) => file_contents,
-            Err(err) => {
-                let default_config = Config::default();
-                if let ErrorKind::NotFound = err.kind() {
-                    warn!("could not find config file at: '{}'", config_file.display());
-                    std::fs::DirBuilder::new()
-                        .recursive(true)
-                        .create(config_directory)
-                        .unwrap_or_else(|err| error!("could not create config directory: {err}"));
-                    std::fs::write(
-                        &config_file,
-                        toml::to_string_pretty(&default_config).unwrap(),
-                    )
-                    .unwrap_or_else(|err| error!("could not write default config file: {err}"));
-                    info!(
-                        "created a new default config file at: '{}'",
-                        config_file.display()
-                    );
-                }
-                return default_config;
+    info!("loading config file at: '{}'", config_file.display());
+
+    let file_contents = match std::fs::read_to_string(&config_file) {
+        Ok(file_contents) => file_contents,
+        Err(err) => {
+            let default_config = Config::default();
+            if let ErrorKind::NotFound = err.kind() {
+                warn!("could not find config file at: '{}'", config_file.display());
+                std::fs::DirBuilder::new()
+                    .recursive(true)
+                    .create(config_directory)
+                    .unwrap_or_else(|err| error!("could not create config directory: {err}"));
+                std::fs::write(
+                    &config_file,
+                    toml::to_string_pretty(&default_config).unwrap(),
+                )
+                .unwrap_or_else(|err| error!("could not write default config file: {err}"));
+                info!(
+                    "created a new default config file at: '{}'",
+                    config_file.display()
+                );
             }
-        };
-
-        match toml::from_str(&file_contents) {
-            Ok(config) => config,
-            Err(err) => {
-                error!("could not parse the config file: {}", err);
-                warn!("loading with default settings");
-                Config::default()
-            }
+            return default_config;
         }
-    } else {
-        error!("could not obtain config directory path");
-        warn!("loading with default settings");
-        Config::default()
+    };
+
+    match toml::from_str(&file_contents) {
+        Ok(config) => config,
+        Err(err) => {
+            error!("could not parse the config file: {}", err);
+            warn!("loading with default settings");
+            Config::default()
+        }
     }
 }
 
 fn save_config(settings_config: &Config) {
-    if let Some(proj_dirs) = ProjectDirs::from("", "", env!("CARGO_PKG_NAME")) {
-        let mut config_file = std::path::PathBuf::from(proj_dirs.config_dir());
-        config_file.push(CONFIG_FILE_NAME);
+    let mut config_file = paths::PATHS
+        .get()
+        .expect("paths should be initialized")
+        .get_config_dir_path()
+        .to_path_buf();
 
-        if let Err(err) = std::fs::write(
-            &config_file,
-            toml::to_string_pretty(&settings_config).unwrap(),
-        ) {
-            error!(
-                "Could not write default config file '{}': {}",
-                config_file.display(),
-                err
-            );
-        }
-    } else {
-        error!("could not obtain config directory path when saving the settings");
+    config_file.push(CONFIG_FILE_NAME);
+
+    if let Err(err) = std::fs::write(
+        &config_file,
+        toml::to_string_pretty(&settings_config).unwrap(),
+    ) {
+        error!(
+            "Could not write default config file '{}': {}",
+            config_file.display(),
+            err
+        );
     }
 }
 

--- a/src/core/settings_config.rs
+++ b/src/core/settings_config.rs
@@ -1,5 +1,6 @@
 use std::{
     io::ErrorKind,
+    path::PathBuf,
     sync::{Arc, RwLock},
 };
 
@@ -34,6 +35,7 @@ pub struct Config {
     pub appearance: AppearanceSettings,
     pub locale: LocaleSettings,
     pub notifications: NotificationSettings,
+    pub custom_paths: Option<CustomPaths>,
 }
 
 #[derive(Clone, Default, Debug, Serialize, Deserialize, Eq, PartialEq)]
@@ -64,6 +66,12 @@ impl Default for NotificationSettings {
     fn default() -> Self {
         Self { time_to_notify: 60 }
     }
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, Eq, PartialEq, Default)]
+pub struct CustomPaths {
+    pub data_dir: Option<PathBuf>,
+    pub cache_dir: Option<PathBuf>,
 }
 
 lazy_static! {
@@ -131,8 +139,8 @@ pub const CONFIG_FILE_NAME: &str = "config.toml";
 
 fn load_config() -> Config {
     let config_directory = paths::PATHS
-        .get()
-        .expect("paths should be initialized")
+        .read()
+        .expect("failed to read paths")
         .get_config_dir_path()
         .to_path_buf();
 
@@ -177,8 +185,8 @@ fn load_config() -> Config {
 
 fn save_config(settings_config: &Config) {
     let mut config_file = paths::PATHS
-        .get()
-        .expect("paths should be initialized")
+        .read()
+        .expect("failed to read paths")
         .get_config_dir_path()
         .to_path_buf();
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,17 +1,10 @@
-use clap::Parser;
-
 pub mod core;
 mod gui;
 
 use iced::{window, Application, Settings};
 
 fn main() -> anyhow::Result<()> {
-    let cli_command = core::cli::cli_data::Cli::parse().command;
-
-    if let Some(command) = cli_command {
-        core::cli::handle_cli::handle_cli(command)?;
-        std::process::exit(0);
-    }
+    core::cli::cli_handler::handle_cli()?;
 
     let subscriber = tracing_subscriber::FmtSubscriber::new();
     tracing::subscriber::set_global_default(subscriber)?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,10 +4,10 @@ mod gui;
 use iced::{window, Application, Settings};
 
 fn main() -> anyhow::Result<()> {
-    core::cli::cli_handler::handle_cli()?;
-
     let subscriber = tracing_subscriber::FmtSubscriber::new();
     tracing::subscriber::set_global_default(subscriber)?;
+
+    core::cli::cli_handler::handle_cli()?;
 
     tracing::info!("starting '{}'", env!("CARGO_PKG_NAME"));
 


### PR DESCRIPTION
This PR adds the ability to specify custom paths for cache, data and config directories of the program making it possible to store program data in locations that are not platform specific. The paths can be provided through the command-line or set via the config file as follows
```toml
[custom_paths]
data_dir = "/path/to/data"
cache_dir = "/path/to/cache"
```
Supplying paths via the command-line will override the ones in the config if available. Custom config directory is not configurable through the config file.