### PR TITLE
Watchlist episode info improvement

### DIFF
--- a/src/gui/message.rs
+++ b/src/gui/message.rs
@@ -1,18 +1,21 @@
-/// Usefull message to be used for widgets stored in an ordered collection like `Vec`
+/// Message to be used for widgets stored in an ordered collection like `Vec`
+/// or in any form that needs to distinguish one from the other when multiple
+/// of the same widgets are used.
 #[derive(Debug, Clone)]
-pub struct IndexedMessage<T> {
-    index: usize,
+pub struct IndexedMessage<I, T> {
+    index: I,
     message: T,
 }
 
-impl<T> IndexedMessage<T> {
-    /// Create `IndexedMessage`
-    pub fn new(index: usize, message: T) -> Self {
+impl<I, T> IndexedMessage<I, T> {
+    pub fn new(index: I, message: T) -> Self {
         Self { index, message }
     }
 
-    /// Get the index of the element to which the message belong
-    pub fn index(&self) -> usize {
+    pub fn index(&self) -> I
+    where
+        I: Copy,
+    {
         self.index
     }
 

--- a/src/gui/series_page/mod.rs
+++ b/src/gui/series_page/mod.rs
@@ -3,15 +3,17 @@ use std::sync::mpsc;
 use iced::{Command, Element, Renderer};
 use indexmap::IndexMap;
 
-use series::{IdentifiableMessage, Series};
+use series::{Message as SeriesMessage, Series};
 
 use crate::core::api::tv_maze::series_information::SeriesMainInformation;
+
+use super::troxide_widget::series_poster::IndexedMessage;
 
 mod series;
 
 #[derive(Debug, Clone)]
 pub enum Message {
-    Series(IdentifiableMessage),
+    Series(IndexedMessage<u32, SeriesMessage>),
     SeriesCacheFileWritten,
 }
 
@@ -52,7 +54,7 @@ impl<'a> SeriesPageController<'a> {
                 let id = *id;
                 series_page
                     .restore_scroller_relative_offset()
-                    .map(move |message| Message::Series(IdentifiableMessage::new(id, message)))
+                    .map(move |message| Message::Series(IndexedMessage::new(id, message)))
             })
             .unwrap_or(Command::none())
     }
@@ -76,7 +78,7 @@ impl<'a> SeriesPageController<'a> {
                     self.series_pages.insert(series_page_id, series_page);
 
                     restore_scroller_command.map(move |message| {
-                        Message::Series(IdentifiableMessage::new(series_page_id, message))
+                        Message::Series(IndexedMessage::new(series_page_id, message))
                     })
                 } else {
                     let (series_page, series_page_command) =
@@ -84,7 +86,7 @@ impl<'a> SeriesPageController<'a> {
                     self.series_pages.insert(series_page_id, series_page);
 
                     series_page_command.map(move |message| {
-                        Message::Series(IdentifiableMessage::new(series_page_id, message))
+                        Message::Series(IndexedMessage::new(series_page_id, message))
                     })
                 };
 
@@ -145,14 +147,14 @@ impl<'a> SeriesPageController<'a> {
     pub fn update(&mut self, message: Message) -> Command<Message> {
         match message {
             Message::Series(identifiable_message) => {
-                let series_page_id = identifiable_message.get_id();
+                let series_page_id = identifiable_message.index();
 
                 let command = if let Some(series_page) = self.series_pages.get_mut(&series_page_id)
                 {
                     series_page
-                        .update(identifiable_message.get_message())
+                        .update(identifiable_message.message())
                         .map(move |message| {
-                            Message::Series(IdentifiableMessage::new(series_page_id, message))
+                            Message::Series(IndexedMessage::new(series_page_id, message))
                         })
                 } else {
                     Command::none()
@@ -168,7 +170,7 @@ impl<'a> SeriesPageController<'a> {
         self.series_pages.last().map(|(id, series_page)| {
             series_page
                 .view()
-                .map(|message| Message::Series(IdentifiableMessage::new(*id, message)))
+                .map(|message| Message::Series(IndexedMessage::new(*id, message)))
         })
     }
 }

--- a/src/gui/series_page/series/cast_widget.rs
+++ b/src/gui/series_page/series/cast_widget.rs
@@ -12,7 +12,7 @@ const INITIAL_CAST_NUMBER: usize = 20;
 #[derive(Clone, Debug)]
 pub enum Message {
     CastReceived(Vec<Cast>),
-    Cast(IndexedCastMessage<CastMessage>),
+    Cast(IndexedCastMessage<usize, CastMessage>),
     Expand,
     Shrink,
 }
@@ -192,7 +192,7 @@ mod cast_poster {
     }
 
     impl CastPoster {
-        pub fn new(id: usize, cast: Cast) -> (Self, Command<IndexedMessage<Message>>) {
+        pub fn new(id: usize, cast: Cast) -> (Self, Command<IndexedMessage<usize, Message>>) {
             let image = cast.person.image.clone();
             let poster = Self {
                 index: id,
@@ -211,8 +211,8 @@ mod cast_poster {
 
         pub fn update(
             &mut self,
-            message: IndexedMessage<Message>,
-        ) -> Command<IndexedMessage<Message>> {
+            message: IndexedMessage<usize, Message>,
+        ) -> Command<IndexedMessage<usize, Message>> {
             let command = match message.message() {
                 Message::PersonImageLoaded(image) => {
                     self.person_image = image;
@@ -244,7 +244,7 @@ mod cast_poster {
             command.map(move |message| IndexedMessage::new(index, message))
         }
 
-        pub fn view(&self) -> Element<'_, IndexedMessage<Message>, Renderer> {
+        pub fn view(&self) -> Element<'_, IndexedMessage<usize, Message>, Renderer> {
             let mut content = Row::new().spacing(10);
 
             let empty_image = helpers::empty_image::empty_image().width(100).height(140);

--- a/src/gui/series_page/series/mod.rs
+++ b/src/gui/series_page/series/mod.rs
@@ -159,37 +159,12 @@ fn tracking_button(series_id: u32) -> Button<'static, Message, Renderer> {
     .style(styles::button_styles::transparent_button_theme())
 }
 
-/// This Series Message is useful to make sure that the appropiate
-/// series page receives it's exact series message. Since the series
-/// page can be switched rapidly by the user, some of the commands
-/// might be running in the background and my complete when a new instance
-/// of series page has been opened updating it with wrong data.
-#[derive(Clone, Debug)]
-pub struct IdentifiableMessage {
-    pub id: u32,
-    pub message: Message,
-}
-
-impl IdentifiableMessage {
-    pub fn new(id: u32, message: Message) -> Self {
-        Self { id, message }
-    }
-
-    pub fn get_id(&self) -> u32 {
-        self.id
-    }
-
-    pub fn get_message(self) -> Message {
-        self.message
-    }
-}
-
 #[derive(Clone, Debug)]
 pub enum Message {
     SeriesImageLoaded(Option<Bytes>),
     SeriesBackgroundLoaded(Option<Bytes>),
     EpisodeListLoaded(caching::episode_list::EpisodeList),
-    Season(SeasonIndexedMessage<SeasonMessage>),
+    Season(SeasonIndexedMessage<usize, SeasonMessage>),
     CastWidgetAction(CastWidgetMessage),
     SeriesSuggestion(SeriesSuggestionMessage),
     PageScrolled(Viewport),

--- a/src/gui/series_page/series/series_suggestion_widget.rs
+++ b/src/gui/series_page/series/series_suggestion_widget.rs
@@ -13,7 +13,7 @@ use iced_aw::{Spinner, Wrap};
 #[derive(Debug, Clone)]
 pub enum Message {
     FullScheduleLoaded(&'static full_schedule::FullSchedule),
-    SeriesPoster(SeriesPosterIndexedMessage<SeriesPosterMessage>),
+    SeriesPoster(SeriesPosterIndexedMessage<usize, SeriesPosterMessage>),
 }
 
 enum LoadState {

--- a/src/gui/tabs/discover_tab/full_schedule.rs
+++ b/src/gui/tabs/discover_tab/full_schedule.rs
@@ -45,14 +45,14 @@ const GENRE_SECTIONS: [Genre; 8] = [
 #[derive(Debug, Clone)]
 pub enum Message {
     FullScheduleLoaded(&'static caching::tv_schedule::full_schedule::FullSchedule),
-    MonthlyNewPosters(SeriesPosterIndexedMessage<SeriesPosterMessage>),
-    MonthlyReturningPosters(SeriesPosterIndexedMessage<SeriesPosterMessage>),
-    GlobalSeries(SeriesPosterIndexedMessage<SeriesPosterMessage>),
-    LocalSeries(SeriesPosterIndexedMessage<SeriesPosterMessage>),
-    PopularPosters(SeriesPosterIndexedMessage<SeriesPosterMessage>),
-    NetworkPosters(SeriesPosterIndexedMessage<SeriesPosterMessage>),
-    WebChannelPosters(SeriesPosterIndexedMessage<SeriesPosterMessage>),
-    GenrePosters(SeriesPosterIndexedMessage<SeriesPosterMessage>),
+    MonthlyNewPosters(SeriesPosterIndexedMessage<usize, SeriesPosterMessage>),
+    MonthlyReturningPosters(SeriesPosterIndexedMessage<usize, SeriesPosterMessage>),
+    GlobalSeries(SeriesPosterIndexedMessage<usize, SeriesPosterMessage>),
+    LocalSeries(SeriesPosterIndexedMessage<usize, SeriesPosterMessage>),
+    PopularPosters(SeriesPosterIndexedMessage<usize, SeriesPosterMessage>),
+    NetworkPosters(SeriesPosterIndexedMessage<usize, SeriesPosterMessage>),
+    WebChannelPosters(SeriesPosterIndexedMessage<usize, SeriesPosterMessage>),
+    GenrePosters(SeriesPosterIndexedMessage<usize, SeriesPosterMessage>),
 }
 
 enum LoadState {
@@ -353,7 +353,7 @@ impl<'a> FullSchedulePosters<'a> {
         series_page_sender: mpsc::Sender<SeriesMainInformation>,
     ) -> (
         Vec<SeriesPoster<'a>>,
-        Vec<Command<SeriesPosterIndexedMessage<SeriesPosterMessage>>>,
+        Vec<Command<SeriesPosterIndexedMessage<usize, SeriesPosterMessage>>>,
     ) {
         let mut posters = Vec::with_capacity(series_infos.len());
         let mut posters_commands = Vec::with_capacity(series_infos.len());
@@ -391,7 +391,7 @@ fn no_series_found() -> Element<'static, Message, Renderer> {
 fn series_posters_viewer<'a>(
     title: &str,
     posters: &'a [SeriesPoster],
-) -> Element<'a, SeriesPosterIndexedMessage<SeriesPosterMessage>, Renderer> {
+) -> Element<'a, SeriesPosterIndexedMessage<usize, SeriesPosterMessage>, Renderer> {
     let title = text(title).size(21);
 
     if posters.is_empty() {
@@ -444,7 +444,7 @@ where
         &mut self,
         section_id: T,
         series_infos: Vec<&'a SeriesMainInformation>,
-        message: fn(SeriesPosterIndexedMessage<SeriesPosterMessage>) -> Message,
+        message: fn(SeriesPosterIndexedMessage<usize, SeriesPosterMessage>) -> Message,
     ) -> Command<Message> {
         if self.posters.is_empty() {
             let range = 0..=(series_infos.len() - 1);
@@ -476,7 +476,7 @@ where
         series_page_sender: mpsc::Sender<SeriesMainInformation>,
     ) -> (
         Vec<SeriesPoster<'a>>,
-        Vec<Command<SeriesPosterIndexedMessage<SeriesPosterMessage>>>,
+        Vec<Command<SeriesPosterIndexedMessage<usize, SeriesPosterMessage>>>,
     ) {
         assert_eq!(range.clone().count(), series_infos.len());
 
@@ -507,7 +507,7 @@ where
     pub fn get_section_view(
         &self,
         section_id: &T,
-        message: fn(SeriesPosterIndexedMessage<SeriesPosterMessage>) -> Message,
+        message: fn(SeriesPosterIndexedMessage<usize, SeriesPosterMessage>) -> Message,
     ) -> Element<'_, Message, Renderer> {
         let series_posters = self.get_section(section_id);
 
@@ -533,8 +533,8 @@ where
 
     pub fn update_poster(
         &mut self,
-        message: SeriesPosterIndexedMessage<SeriesPosterMessage>,
-    ) -> Command<SeriesPosterIndexedMessage<SeriesPosterMessage>> {
+        message: SeriesPosterIndexedMessage<usize, SeriesPosterMessage>,
+    ) -> Command<SeriesPosterIndexedMessage<usize, SeriesPosterMessage>> {
         let index = message.index();
         self.posters[index].update(message)
     }

--- a/src/gui/tabs/discover_tab/searching.rs
+++ b/src/gui/tabs/discover_tab/searching.rs
@@ -25,7 +25,7 @@ pub enum Message {
     TermSearched,
     SearchSuccess(Vec<series_searching::SeriesSearchResult>),
     SearchFail,
-    SearchResult(SearchResultIndexedMessage<SearchResultMessage>),
+    SearchResult(SearchResultIndexedMessage<usize, SearchResultMessage>),
     EscapeKeyPressed,
 }
 
@@ -200,7 +200,7 @@ mod search_result {
             index: usize,
             search_result: series_searching::SeriesSearchResult,
             series_page_sender: mpsc::Sender<SeriesMainInformation>,
-        ) -> (Self, Command<IndexedMessage<Message>>) {
+        ) -> (Self, Command<IndexedMessage<usize, Message>>) {
             let image_url = search_result.show.image.clone();
             (
                 Self {
@@ -221,7 +221,7 @@ mod search_result {
             )
         }
 
-        pub fn update(&mut self, message: IndexedMessage<Message>) {
+        pub fn update(&mut self, message: IndexedMessage<usize, Message>) {
             match message.message() {
                 Message::ImageLoaded(image) => self.image = image,
                 Message::SeriesResultPressed => {
@@ -232,7 +232,7 @@ mod search_result {
             }
         }
 
-        pub fn view(&self) -> Element<'_, IndexedMessage<Message>, Renderer> {
+        pub fn view(&self) -> Element<'_, IndexedMessage<usize, Message>, Renderer> {
             let mut row = row!().spacing(5).padding(5);
 
             if let Some(image_bytes) = self.image.clone() {

--- a/src/gui/tabs/my_shows_tab/my_shows_widget.rs
+++ b/src/gui/tabs/my_shows_tab/my_shows_widget.rs
@@ -13,7 +13,7 @@ use crate::gui::troxide_widget::series_poster::{
 
 #[derive(Debug, Clone)]
 pub enum Message {
-    SeriesPosters(SeriesPosterIndexedMessage<SeriesPosterMessage>),
+    SeriesPosters(SeriesPosterIndexedMessage<usize, SeriesPosterMessage>),
     SeriesInformationReceived(Option<Vec<SeriesMainInformation>>),
 }
 

--- a/src/gui/tabs/my_shows_tab/upcoming_releases_widget.rs
+++ b/src/gui/tabs/my_shows_tab/upcoming_releases_widget.rs
@@ -14,7 +14,7 @@ use upcoming_poster::{Message as UpcomingPosterMessage, UpcomingPoster};
 
 #[derive(Debug, Clone)]
 pub enum Message {
-    UpcomingPoster(IndexedMessage<UpcomingPosterMessage>),
+    UpcomingPoster(IndexedMessage<usize, UpcomingPosterMessage>),
     SeriesInformationReceived(Option<Vec<(SeriesMainInformation, Episode, EpisodeReleaseTime)>>),
     Refresh,
 }
@@ -185,7 +185,7 @@ mod upcoming_poster {
             series_page_sender: mpsc::Sender<SeriesMainInformation>,
             upcoming_episode: Episode,
             episode_release_time: EpisodeReleaseTime,
-        ) -> (Self, Command<IndexedMessage<Message>>) {
+        ) -> (Self, Command<IndexedMessage<usize, Message>>) {
             let (poster, poster_command) = GenericPoster::new(series_info, series_page_sender);
             (
                 Self {
@@ -206,8 +206,8 @@ mod upcoming_poster {
 
         pub fn update(
             &mut self,
-            message: IndexedMessage<Message>,
-        ) -> Command<IndexedMessage<Message>> {
+            message: IndexedMessage<usize, Message>,
+        ) -> Command<IndexedMessage<usize, Message>> {
             match message.message() {
                 Message::Poster(message) => {
                     self.poster.update(message);
@@ -220,7 +220,7 @@ mod upcoming_poster {
             }
         }
 
-        pub fn view(&self) -> Element<'_, IndexedMessage<Message>, Renderer> {
+        pub fn view(&self) -> Element<'_, IndexedMessage<usize, Message>, Renderer> {
             let mut content = row!().padding(2).spacing(7);
             if let Some(image_bytes) = self.poster.get_image() {
                 let image_handle = image::Handle::from_memory(image_bytes.clone());

--- a/src/gui/tabs/statistics_tab/mini_widgets.rs
+++ b/src/gui/tabs/statistics_tab/mini_widgets.rs
@@ -205,7 +205,7 @@ pub mod series_banner {
             series_info: std::borrow::Cow<'a, SeriesMainInformation>,
             watch_time: Option<u32>,
             series_page_sender: mpsc::Sender<SeriesMainInformation>,
-        ) -> (Self, Command<IndexedMessage<Message>>) {
+        ) -> (Self, Command<IndexedMessage<usize, Message>>) {
             let (poster, poster_command) = GenericPoster::new(series_info, series_page_sender);
             (
                 Self {
@@ -219,14 +219,14 @@ pub mod series_banner {
             )
         }
 
-        pub fn update(&mut self, message: IndexedMessage<Message>) {
+        pub fn update(&mut self, message: IndexedMessage<usize, Message>) {
             match message.message() {
                 Message::Selected => self.poster.open_series_page(),
                 Message::Poster(message) => self.poster.update(message),
             }
         }
 
-        pub fn view(&self) -> Element<'_, IndexedMessage<Message>, Renderer> {
+        pub fn view(&self) -> Element<'_, IndexedMessage<usize, Message>, Renderer> {
             let series_id = self.poster.get_series_info().id;
             let series = database::DB.get_series(series_id).unwrap();
 

--- a/src/gui/tabs/statistics_tab/mod.rs
+++ b/src/gui/tabs/statistics_tab/mod.rs
@@ -21,7 +21,7 @@ mod mini_widgets;
 #[derive(Clone, Debug)]
 pub enum Message {
     SeriesInfosAndTimeReceived(Vec<(SeriesMainInformation, Option<u32>)>),
-    SeriesBanner(SeriesBannerIndexedMessage<SeriesBannerMessage>),
+    SeriesBanner(SeriesBannerIndexedMessage<usize, SeriesBannerMessage>),
     PageScrolled(Viewport),
 }
 

--- a/src/gui/tabs/watchlist_tab.rs
+++ b/src/gui/tabs/watchlist_tab.rs
@@ -19,7 +19,7 @@ use watchlist_summary::WatchlistSummary;
 #[derive(Debug, Clone)]
 pub enum Message {
     SeriesInformationLoaded(Vec<(SeriesMainInformation, EpisodeList, usize)>),
-    WatchlistPoster(IndexedMessage<WatchlistPosterMessage>),
+    WatchlistPoster(IndexedMessage<usize, WatchlistPosterMessage>),
     PageScrolled(Viewport),
 }
 
@@ -267,7 +267,7 @@ mod watchlist_poster {
             episode_list: EpisodeList,
             total_series_episodes: usize,
             series_page_sender: mpsc::Sender<SeriesMainInformation>,
-        ) -> (Self, Command<IndexedMessage<Message>>) {
+        ) -> (Self, Command<IndexedMessage<usize, Message>>) {
             let (poster, poster_command) = GenericPoster::new(series_info, series_page_sender);
 
             (
@@ -287,8 +287,8 @@ mod watchlist_poster {
 
         pub fn update(
             &mut self,
-            message: IndexedMessage<Message>,
-        ) -> Command<IndexedMessage<Message>> {
+            message: IndexedMessage<usize, Message>,
+        ) -> Command<IndexedMessage<usize, Message>> {
             let command = match message.message() {
                 Message::Poster(message) => {
                     self.poster.update(message);
@@ -334,7 +334,7 @@ mod watchlist_poster {
             Command::batch([episode_update_command, command])
         }
 
-        fn update_episode_poster(&mut self) -> Command<IndexedMessage<Message>> {
+        fn update_episode_poster(&mut self) -> Command<IndexedMessage<usize, Message>> {
             if let Some(episode) = self.episode_list.get_next_episode_to_watch() {
                 let (episode_poster, episode_poster_command) = EpisodePoster::new(
                     0,
@@ -352,7 +352,7 @@ mod watchlist_poster {
             }
         }
 
-        pub fn view(&self) -> Element<'_, IndexedMessage<Message>, Renderer> {
+        pub fn view(&self) -> Element<'_, IndexedMessage<usize, Message>, Renderer> {
             let mut content = row!().padding(2).spacing(5);
             if let Some(image_bytes) = self.poster.get_image() {
                 let image_handle = image::Handle::from_memory(image_bytes.clone());

--- a/src/gui/troxide_widget.rs
+++ b/src/gui/troxide_widget.rs
@@ -43,7 +43,7 @@ pub mod episode_widget {
             series_id: u32,
             series_name: String,
             episode_information: EpisodeInfo,
-        ) -> (Self, Command<IndexedMessage<Message>>) {
+        ) -> (Self, Command<IndexedMessage<usize, Message>>) {
             let episode_image = episode_information.image.clone();
             let episode = Self {
                 index,
@@ -73,8 +73,8 @@ pub mod episode_widget {
 
         pub fn update(
             &mut self,
-            message: IndexedMessage<Message>,
-        ) -> Command<IndexedMessage<Message>> {
+            message: IndexedMessage<usize, Message>,
+        ) -> Command<IndexedMessage<usize, Message>> {
             match message.message() {
                 Message::ImageLoaded(image) => {
                     self.episode_image = image;
@@ -130,7 +130,7 @@ pub mod episode_widget {
         pub fn view(
             &self,
             poster_type: PosterType,
-        ) -> Element<'_, IndexedMessage<Message>, Renderer> {
+        ) -> Element<'_, IndexedMessage<usize, Message>, Renderer> {
             let (poster_width, image_width, image_height) = match poster_type {
                 PosterType::Watchlist => (800_f32, 124_f32, 70_f32),
                 PosterType::Season => (700_f32, 107_f32, 60_f32),
@@ -353,7 +353,7 @@ pub mod series_poster {
             index: usize,
             series_information: Cow<'a, SeriesMainInformation>,
             series_page_sender: mpsc::Sender<SeriesMainInformation>,
-        ) -> (Self, Command<IndexedMessage<Message>>) {
+        ) -> (Self, Command<IndexedMessage<usize, Message>>) {
             let (poster, poster_command) =
                 GenericPoster::new(series_information, series_page_sender);
             let poster = Self {
@@ -373,8 +373,8 @@ pub mod series_poster {
 
         pub fn update(
             &mut self,
-            message: IndexedMessage<Message>,
-        ) -> Command<IndexedMessage<Message>> {
+            message: IndexedMessage<usize, Message>,
+        ) -> Command<IndexedMessage<usize, Message>> {
             match message.message() {
                 Message::SeriesPosterPressed => {
                     self.poster.open_series_page();
@@ -410,7 +410,10 @@ pub mod series_poster {
             self.hidden
         }
 
-        pub fn view(&self, expandable: bool) -> Element<'_, IndexedMessage<Message>, Renderer> {
+        pub fn view(
+            &self,
+            expandable: bool,
+        ) -> Element<'_, IndexedMessage<usize, Message>, Renderer> {
             let poster_image: Element<'_, Message, Renderer> = {
                 let image_height = if self.expanded { 170 } else { 140 };
                 if let Some(image_bytes) = self.poster.get_image() {


### PR DESCRIPTION
This PR improves the episode info in watchlist posters by preventing mixing of images as episodes are marked watched and prevent panic when there are no more episodes left to watch in some cases (When there is no episode left to watch and an asynchronous event of an old episode info just completes)