### PR TITLE
Bugfix/search results loading

### DIFF
--- a/src/gui/tabs/discover_tab/searching.rs
+++ b/src/gui/tabs/discover_tab/searching.rs
@@ -66,23 +66,24 @@ impl Search {
             Message::TermChanged(term) => {
                 self.search_term = term;
                 self.load_state = LoadState::NotLoaded;
+                Command::none()
             }
             Message::TermSearched => {
                 if self.search_term == self.searched_term {
                     if !self.search_results.is_empty() {
                         self.load_state = LoadState::Loaded;
                     }
-                    return Command::none();
+                    Command::none()
                 } else {
                     self.load_state = LoadState::Loading;
                     self.searched_term = self.search_term.clone();
 
                     let series_result = series_searching::search_series(self.search_term.clone());
 
-                    return Command::perform(series_result, |res| match res {
+                    Command::perform(series_result, |res| match res {
                         Ok(res) => Message::SearchSuccess(res),
                         Err(_) => Message::SearchFail,
-                    });
+                    })
                 }
             }
             Message::SearchSuccess(results) => {
@@ -99,18 +100,21 @@ impl Search {
 
                 self.search_results = search_results;
 
-                return Command::batch(search_results_commands);
+                Command::batch(search_results_commands)
             }
             Message::SearchFail => panic!("Series Search Failed"),
             Message::SearchResult(message) => {
                 if let SearchResultMessage::SeriesResultPressed = message.clone().message() {
                     self.load_state = LoadState::NotLoaded;
                 }
-                self.search_results[message.index()].update(message)
+                self.search_results[message.index()].update(message);
+                Command::none()
             }
-            Message::EscapeKeyPressed => self.load_state = LoadState::NotLoaded,
+            Message::EscapeKeyPressed => {
+                self.load_state = LoadState::NotLoaded;
+                Command::none()
+            }
         }
-        Command::none()
     }
 
     pub fn view(

--- a/src/gui/tabs/discover_tab/searching.rs
+++ b/src/gui/tabs/discover_tab/searching.rs
@@ -21,7 +21,7 @@ pub enum LoadState {
 pub enum Message {
     TermChanged(String),
     TermSearched,
-    SearchSuccess(Result<Vec<series_searching::SeriesSearchResult>, String>),
+    SearchResultsReceived(Result<Vec<series_searching::SeriesSearchResult>, String>),
     SearchResult(IndexedMessage<usize, SearchResultMessage>),
     EscapeKeyPressed,
 }
@@ -85,11 +85,11 @@ impl Search {
                     let series_result = series_searching::search_series(self.search_term.clone());
 
                     Command::perform(series_result, |res| {
-                        Message::SearchSuccess(res.map_err(|err| err.to_string()))
+                        Message::SearchResultsReceived(res.map_err(|err| err.to_string()))
                     })
                 }
             }
-            Message::SearchSuccess(results) => {
+            Message::SearchResultsReceived(results) => {
                 self.load_state = LoadState::Loaded;
 
                 match results {


### PR DESCRIPTION
This PR fixes possible panic when searching for series fails through the search bar. It also prevents unnecessary request when the series searched is the same as the previous one by reusing the results obtained from the previous search.