### PR TITLE
Implement search bars for tabs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1397,6 +1397,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "fuzzy-matcher"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54614a3312934d066701a80f20f15fa3b56d67ac7722b39eea5b4c9dd1d66c94"
+dependencies = [
+ "thread_local",
+]
+
+[[package]]
 name = "fxhash"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3840,6 +3849,7 @@ dependencies = [
  "chrono",
  "clap",
  "directories",
+ "fuzzy-matcher",
  "html2text",
  "iced",
  "iced_aw",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,6 +44,7 @@ num-traits = "0.2.17"
 semver = "1.0.20"
 ron = "0.8.1"
 smallvec = "1.11.2"
+fuzzy-matcher = "0.3.7"
 
 [build-dependencies]
 built = { version = "0.7.1", features = ["git2", "chrono"] }

--- a/src/gui/tabs/mod.rs
+++ b/src/gui/tabs/mod.rs
@@ -13,6 +13,7 @@ pub mod discover_tab;
 pub mod my_shows_tab;
 pub mod settings_tab;
 pub mod statistics_tab;
+pub mod tab_searching;
 pub mod watchlist_tab;
 
 pub trait Tab {

--- a/src/gui/tabs/my_shows_tab/my_shows_widget.rs
+++ b/src/gui/tabs/my_shows_tab/my_shows_widget.rs
@@ -1,12 +1,13 @@
 use std::sync::mpsc;
 
-use iced::widget::{container, text};
+use iced::widget::container;
 use iced::{Command, Element, Length, Renderer};
 use iced_aw::{Spinner, Wrap};
 
 use crate::core::api::tv_maze::series_information::SeriesMainInformation;
 use crate::core::caching;
 use crate::gui::styles;
+use crate::gui::tabs::tab_searching::{unavailable_posters, Searchable};
 use crate::gui::troxide_widget::series_poster::{
     IndexedMessage, Message as SeriesPosterMessage, SeriesPoster,
 };
@@ -28,6 +29,8 @@ pub struct MyShows<'a> {
     load_state: LoadState,
     series_posters: Vec<SeriesPoster<'a>>,
     series_page_sender: mpsc::Sender<SeriesMainInformation>,
+    /// A collection of matched series id after a fuzzy search
+    matched_id_collection: Option<Vec<u32>>,
 }
 
 impl<'a> MyShows<'a> {
@@ -39,6 +42,7 @@ impl<'a> MyShows<'a> {
                 load_state: LoadState::default(),
                 series_posters: vec![],
                 series_page_sender,
+                matched_id_collection: None,
             },
             Command::perform(
                 async {
@@ -59,6 +63,7 @@ impl<'a> MyShows<'a> {
                 load_state: LoadState::default(),
                 series_posters: vec![],
                 series_page_sender,
+                matched_id_collection: None,
             },
             Command::perform(
                 async {
@@ -79,6 +84,7 @@ impl<'a> MyShows<'a> {
                 load_state: LoadState::default(),
                 series_posters: vec![],
                 series_page_sender,
+                matched_id_collection: None,
             },
             Command::perform(
                 async {
@@ -131,23 +137,58 @@ impl<'a> MyShows<'a> {
                 .into();
         }
         if self.series_posters.is_empty() {
-            container(text("Nothing to show"))
-                .style(styles::container_styles::first_class_container_square_theme())
-                .center_x()
-                .center_y()
-                .height(200)
-                .width(Length::Fill)
-                .into()
+            Self::empty_myshows_posters()
         } else {
-            Wrap::with_elements(
-                self.series_posters
-                    .iter()
-                    .map(|poster| poster.view(false).map(Message::SeriesPosters))
-                    .collect(),
-            )
-            .line_spacing(5.0)
-            .spacing(5.0)
-            .into()
+            let series_posters: Vec<Element<'_, Message, Renderer>> = self
+                .series_posters
+                .iter()
+                .filter(|poster| {
+                    if let Some(matched_id_collection) = &self.matched_id_collection {
+                        self.is_matched_id(matched_id_collection, poster.get_series_info().id)
+                    } else {
+                        true
+                    }
+                })
+                .map(|poster| poster.view(false).map(Message::SeriesPosters))
+                .collect();
+
+            if series_posters.is_empty() {
+                Self::no_search_matches()
+            } else {
+                Wrap::with_elements(series_posters)
+                    .line_spacing(5.0)
+                    .spacing(5.0)
+                    .into()
+            }
         }
+    }
+
+    fn empty_myshows_posters() -> Element<'static, Message, Renderer> {
+        unavailable_posters("Nothing to show")
+            .style(styles::container_styles::first_class_container_square_theme())
+            .height(200)
+            .width(Length::Fill)
+            .into()
+    }
+
+    fn no_search_matches() -> Element<'static, Message, Renderer> {
+        unavailable_posters("No matches found!")
+            .style(styles::container_styles::first_class_container_square_theme())
+            .height(200)
+            .width(Length::Fill)
+            .into()
+    }
+}
+
+impl<'a> Searchable for MyShows<'a> {
+    fn get_series_information_collection(&self) -> Vec<&SeriesMainInformation> {
+        self.series_posters
+            .iter()
+            .map(|poster| poster.get_series_info())
+            .collect()
+    }
+
+    fn matches_id_collection(&mut self) -> &mut Option<Vec<u32>> {
+        &mut self.matched_id_collection
     }
 }

--- a/src/gui/tabs/statistics_tab/mini_widgets.rs
+++ b/src/gui/tabs/statistics_tab/mini_widgets.rs
@@ -215,6 +215,10 @@ pub mod series_banner {
             )
         }
 
+        pub fn get_series_info(&self) -> &SeriesMainInformation {
+            self.poster.get_series_info()
+        }
+
         pub fn update(&mut self, message: IndexedMessage<usize, Message>) {
             match message.message() {
                 Message::Selected => self.poster.open_series_page(),

--- a/src/gui/tabs/statistics_tab/mod.rs
+++ b/src/gui/tabs/statistics_tab/mod.rs
@@ -1,7 +1,7 @@
 use std::sync::mpsc;
 
 use iced::widget::scrollable::{RelativeOffset, Viewport};
-use iced::widget::{column, container, row, scrollable, text};
+use iced::widget::{column, container, row, scrollable};
 use iced::{Command, Element, Length, Renderer};
 use iced_aw::Wrap;
 
@@ -12,6 +12,7 @@ use series_banner::{IndexedMessage, Message as SeriesBannerMessage, SeriesBanner
 
 use mini_widgets::*;
 
+use super::tab_searching::{unavailable_posters, Message as SearcherMessage, Searchable, Searcher};
 use super::Tab;
 
 mod mini_widgets;
@@ -21,6 +22,7 @@ pub enum Message {
     SeriesInfosAndTimeReceived(Vec<(SeriesMainInformation, Option<u32>)>),
     SeriesBanner(IndexedMessage<usize, SeriesBannerMessage>),
     PageScrolled(Viewport),
+    Searcher(SearcherMessage),
 }
 
 pub struct StatisticsTab<'a> {
@@ -28,6 +30,9 @@ pub struct StatisticsTab<'a> {
     series_banners: Vec<SeriesBanner<'a>>,
     series_page_sender: mpsc::Sender<SeriesMainInformation>,
     scrollable_offset: RelativeOffset,
+    /// A collection of matched series id after a fuzzy search
+    matched_id_collection: Option<Vec<u32>>,
+    searcher: Searcher,
 }
 
 impl<'a> StatisticsTab<'a> {
@@ -41,6 +46,8 @@ impl<'a> StatisticsTab<'a> {
                 series_banners: vec![],
                 series_page_sender,
                 scrollable_offset: scrollable_offset.unwrap_or(RelativeOffset::START),
+                matched_id_collection: None,
+                searcher: Searcher::new("Search Statistics".to_owned()),
             },
             Command::perform(
                 get_series_with_runtime(),
@@ -81,24 +88,50 @@ impl<'a> StatisticsTab<'a> {
                 self.scrollable_offset = view_port.relative_offset();
                 Command::none()
             }
+            Message::Searcher(message) => {
+                self.searcher.update(message);
+                let current_search_term = self.searcher.current_search_term().to_owned();
+                self.update_matches(&current_search_term);
+                Command::none()
+            }
         }
     }
     pub fn view(&self) -> Element<Message, Renderer> {
         let series_list: Element<'_, Message, Renderer> = if self.series_banners.is_empty() {
-            text("Your watched series will appear here").into()
+            Self::empty_statistics_posters()
         } else {
-            Wrap::with_elements(
-                self.series_banners
-                    .iter()
-                    .map(|banner| banner.view().map(Message::SeriesBanner))
-                    .collect(),
-            )
-            .spacing(5.0)
-            .line_spacing(5.0)
-            .into()
-        };
+            let series_list: Vec<Element<'_, Message, Renderer>> = self
+                .series_banners
+                .iter()
+                .filter(|banner| {
+                    if let Some(matched_id_collection) = &self.matched_id_collection {
+                        self.is_matched_id(matched_id_collection, banner.get_series_info().id)
+                    } else {
+                        true
+                    }
+                })
+                .map(|banner| banner.view().map(Message::SeriesBanner))
+                .collect();
 
-        let series_list = container(series_list).width(Length::Fill).center_x();
+            if series_list.is_empty() {
+                Self::no_search_matches()
+            } else {
+                let series_list = Wrap::with_elements(series_list)
+                    .spacing(5.0)
+                    .line_spacing(5.0);
+
+                scrollable(
+                    container(series_list)
+                        .padding(10)
+                        .width(Length::Fill)
+                        .center_x(),
+                )
+                .id(Self::scrollable_id())
+                .on_scroll(Message::PageScrolled)
+                .direction(styles::scrollable_styles::vertical_direction())
+                .into()
+            }
+        };
 
         let series_infos: Vec<&SeriesMainInformation> = self
             .series_infos_and_time
@@ -106,7 +139,9 @@ impl<'a> StatisticsTab<'a> {
             .map(|(series_info, _)| series_info)
             .collect();
 
-        let content = column![
+        let searcher = self.searcher.view().map(Message::Searcher);
+
+        column![
             row![
                 watch_count(),
                 genre_stats(series_infos),
@@ -114,20 +149,26 @@ impl<'a> StatisticsTab<'a> {
             ]
             .height(200)
             .spacing(10),
+            searcher,
             series_list
         ]
         .spacing(10)
-        .padding(10);
-
-        container(
-            scrollable(content)
-                .id(Self::scrollable_id())
-                .on_scroll(Message::PageScrolled)
-                .direction(styles::scrollable_styles::vertical_direction()),
-        )
-        .width(Length::Fill)
-        .height(Length::Fill)
+        .padding(10)
         .into()
+    }
+
+    fn empty_statistics_posters() -> Element<'static, Message, Renderer> {
+        unavailable_posters("Your watched series will appear here")
+            .width(Length::Fill)
+            .height(Length::Fill)
+            .into()
+    }
+
+    fn no_search_matches() -> Element<'static, Message, Renderer> {
+        unavailable_posters("No matches found!")
+            .width(Length::Fill)
+            .height(Length::Fill)
+            .into()
     }
 }
 
@@ -164,5 +205,18 @@ impl<'a> Tab for StatisticsTab<'a> {
 
     fn get_scrollable_offset(&self) -> scrollable::RelativeOffset {
         self.scrollable_offset
+    }
+}
+
+impl<'a> Searchable for StatisticsTab<'a> {
+    fn get_series_information_collection(&self) -> Vec<&SeriesMainInformation> {
+        self.series_banners
+            .iter()
+            .map(|banner| banner.get_series_info())
+            .collect()
+    }
+
+    fn matches_id_collection(&mut self) -> &mut Option<Vec<u32>> {
+        &mut self.matched_id_collection
     }
 }

--- a/src/gui/tabs/tab_searching.rs
+++ b/src/gui/tabs/tab_searching.rs
@@ -1,0 +1,117 @@
+//! Module responsible with fuzzy searching of Series in a particular tab
+
+use iced::widget::{column, container, text, text_input, Container};
+use iced::{Element, Length, Renderer};
+
+use crate::core::api::tv_maze::series_information::SeriesMainInformation;
+
+/// A trait enabling searching of particular matching `Series`' against a search term in a tab
+pub trait Searchable {
+    /// Retrieves all the `SeriesMainInformation`s available on a particular tab
+    ///
+    /// After retrieving this collection, a search will be performed in the collection
+    /// against a particular search term.
+    fn get_series_information_collection(&self) -> Vec<&SeriesMainInformation>;
+
+    /// Provides a mutable reference to the tab's matched series ids collection so that
+    /// we can update them when the search term changes
+    ///
+    /// The mutable reference to the tab's matched ids is `Optional`. This is to provide a clear
+    /// indication whether no term has be provided to search (`None`), or a term has been provided
+    /// and the reference has `Some` matched ids based upon that search term
+    fn matches_id_collection(&mut self) -> &mut Option<Vec<u32>>;
+
+    /// Checks if a particular `SeriesMainInformation` id is among the matched ids after a search
+    fn is_matched_id(&self, matched_ids: &[u32], id: u32) -> bool {
+        matched_ids.iter().any(|matched_id| *matched_id == id)
+    }
+
+    /// Updates the matched series ids of the tab based on the search term
+    fn update_matches(&mut self, search_term: &str) {
+        let new_matches_ids = Self::search_for_matches(
+            search_term,
+            self.get_series_information_collection().as_slice(),
+        );
+
+        let matches_id_collection = self.matches_id_collection();
+
+        // If the search term is empty, we set the matched_id_collection to None
+        // so as to clearly indicate that situation.
+        if search_term.is_empty() {
+            *matches_id_collection = None;
+            return;
+        }
+
+        *matches_id_collection = Some(new_matches_ids);
+    }
+
+    /// Search for `SeriesMainInformation` matches based on a particular search term returning
+    /// the Series Ids of the matched ones
+    fn search_for_matches(
+        search_term: &str,
+        search_collection: &[&SeriesMainInformation],
+    ) -> Vec<u32> {
+        use fuzzy_matcher::skim::SkimMatcherV2;
+        use fuzzy_matcher::FuzzyMatcher;
+
+        let matcher = SkimMatcherV2::default();
+        search_collection
+            .iter()
+            .filter(|series_info| {
+                matcher
+                    .fuzzy_match(&series_info.name, search_term)
+                    .is_some()
+            })
+            .map(|series_info| series_info.id)
+            .collect()
+    }
+}
+
+#[derive(Debug, Clone)]
+pub enum Message {
+    SearchTermChanged(String),
+}
+
+pub struct Searcher {
+    placeholder: String,
+    current_search_term: String,
+}
+
+impl Searcher {
+    pub fn new(placeholder: String) -> Self {
+        Self {
+            placeholder,
+            current_search_term: String::new(),
+        }
+    }
+
+    pub fn current_search_term(&self) -> &str {
+        &self.current_search_term
+    }
+
+    pub fn update(&mut self, message: Message) {
+        match message {
+            Message::SearchTermChanged(new_search_term) => {
+                self.current_search_term = new_search_term;
+            }
+        }
+    }
+
+    pub fn view(&self) -> Element<'_, Message, Renderer> {
+        let search_bar = column!(text_input(&self.placeholder, &self.current_search_term)
+            .width(300)
+            .on_input(Message::SearchTermChanged))
+        .width(Length::Fill)
+        .align_items(iced::Alignment::Center);
+
+        search_bar.into()
+    }
+}
+
+/// A helper function that produces an `Element` that indicates absence of series posters based
+/// on the supplied absence reason
+pub fn unavailable_posters<Message: 'static>(absence_reason: &str) -> Container<Message> {
+    container(text(absence_reason).horizontal_alignment(iced::alignment::Horizontal::Center))
+        .center_x()
+        .center_y()
+}

--- a/src/gui/tabs/watchlist_tab.rs
+++ b/src/gui/tabs/watchlist_tab.rs
@@ -1,10 +1,11 @@
 use std::sync::mpsc;
 
 use iced::widget::scrollable::{RelativeOffset, Viewport};
-use iced::widget::{column, container, scrollable, text, Column, Space};
+use iced::widget::{column, container, scrollable, Column, Space};
 use iced::{Command, Element, Length, Renderer};
 use iced_aw::Spinner;
 
+use super::tab_searching::{unavailable_posters, Message as SearcherMessage, Searchable, Searcher};
 use super::Tab;
 use crate::core::api::tv_maze::series_information::SeriesMainInformation;
 use crate::core::caching::episode_list::EpisodeList;
@@ -21,6 +22,7 @@ pub enum Message {
     SeriesInformationLoaded(Vec<(SeriesMainInformation, EpisodeList, usize)>),
     WatchlistPoster(IndexedMessage<usize, WatchlistPosterMessage>),
     PageScrolled(Viewport),
+    Searcher(SearcherMessage),
 }
 
 #[derive(Default)]
@@ -36,6 +38,9 @@ pub struct WatchlistTab<'a> {
     watchlist_summary: Option<WatchlistSummary>,
     series_page_sender: mpsc::Sender<SeriesMainInformation>,
     scrollable_offset: RelativeOffset,
+    /// A collection of matched series id after a fuzzy search
+    matched_id_collection: Option<Vec<u32>>,
+    searcher: Searcher,
 }
 
 impl<'a> WatchlistTab<'a> {
@@ -50,6 +55,8 @@ impl<'a> WatchlistTab<'a> {
                 load_state: LoadState::Loading,
                 series_page_sender,
                 scrollable_offset: scrollable_offset.unwrap_or(RelativeOffset::START),
+                matched_id_collection: None,
+                searcher: Searcher::new("Search Watchlist".to_owned()),
             },
             Command::perform(
                 get_series_information_and_watched_episodes(),
@@ -109,6 +116,12 @@ impl<'a> WatchlistTab<'a> {
                 self.scrollable_offset = view_port.relative_offset();
                 Command::none()
             }
+            Message::Searcher(message) => {
+                self.searcher.update(message);
+                let current_search_term = self.searcher.current_search_term().to_owned();
+                self.update_matches(&current_search_term);
+                Command::none()
+            }
         }
     }
     pub fn view(&self) -> Element<Message, Renderer> {
@@ -121,46 +134,71 @@ impl<'a> WatchlistTab<'a> {
                 .into(),
             LoadState::Loaded => {
                 if self.watchlist_posters.is_empty() {
-                    container(
-                        text("All Clear!")
-                            .horizontal_alignment(iced::alignment::Horizontal::Center),
-                    )
-                    .center_x()
-                    .center_y()
-                    .height(Length::Fill)
-                    .width(Length::Fill)
-                    .into()
+                    Self::empty_watchlist_posters()
                 } else {
-                    let watchlist_items: Vec<Element<'_, Message, Renderer>> = self
-                        .watchlist_posters
-                        .iter()
-                        .map(|poster| poster.view().map(Message::WatchlistPoster))
-                        .collect();
-
                     let watchlist_summary = self
                         .watchlist_summary
                         .as_ref()
                         .map(|watchlist_summary| watchlist_summary.view())
                         .unwrap_or(Space::new(0, 0).into());
 
-                    let watchlist_items = Column::with_children(watchlist_items)
-                        .spacing(5)
-                        .align_items(iced::Alignment::Center)
-                        .width(Length::Fill);
+                    let watchlist_items: Vec<Element<'_, Message, Renderer>> = self
+                        .watchlist_posters
+                        .iter()
+                        .filter(|poster| {
+                            if let Some(matched_id_collection) = &self.matched_id_collection {
+                                self.is_matched_id(
+                                    matched_id_collection.as_slice(),
+                                    poster.get_series_info().id,
+                                )
+                            } else {
+                                true
+                            }
+                        })
+                        .map(|poster| poster.view().map(Message::WatchlistPoster))
+                        .collect();
 
-                    let content = column![watchlist_summary, watchlist_items]
+                    let watchlist_items = if watchlist_items.is_empty() {
+                        Self::no_search_matches()
+                    } else {
+                        let watchlist_items = Column::with_children(watchlist_items)
+                            .spacing(5)
+                            .align_items(iced::Alignment::Center)
+                            .width(Length::Fill);
+
+                        // We are wrapping the watchlist_items into a container so that the scrollbar does not touch the watchlist
+                        // element by setting up padding in the container
+                        scrollable(container(watchlist_items).padding(10).width(Length::Fill))
+                            .direction(styles::scrollable_styles::vertical_direction())
+                            .id(Self::scrollable_id())
+                            .on_scroll(Message::PageScrolled)
+                            .into()
+                    };
+
+                    let searcher = self.searcher.view().map(Message::Searcher);
+
+                    column![watchlist_summary, searcher, watchlist_items]
                         .padding(5)
                         .spacing(10)
-                        .align_items(iced::Alignment::Center);
-
-                    scrollable(content)
-                        .direction(styles::scrollable_styles::vertical_direction())
-                        .id(Self::scrollable_id())
-                        .on_scroll(Message::PageScrolled)
+                        .align_items(iced::Alignment::Center)
                         .into()
                 }
             }
         }
+    }
+
+    fn empty_watchlist_posters() -> Element<'static, Message, Renderer> {
+        unavailable_posters("All Clear!")
+            .width(Length::Fill)
+            .height(Length::Fill)
+            .into()
+    }
+
+    fn no_search_matches() -> Element<'static, Message, Renderer> {
+        unavailable_posters("No matches found!")
+            .width(Length::Fill)
+            .height(Length::Fill)
+            .into()
     }
 }
 
@@ -219,6 +257,19 @@ impl<'a> Tab for WatchlistTab<'a> {
 
     fn get_scrollable_offset(&self) -> scrollable::RelativeOffset {
         self.scrollable_offset
+    }
+}
+
+impl<'a> Searchable for WatchlistTab<'a> {
+    fn get_series_information_collection(&self) -> Vec<&SeriesMainInformation> {
+        self.watchlist_posters
+            .iter()
+            .map(|poster| poster.get_series_info())
+            .collect()
+    }
+
+    fn matches_id_collection(&mut self) -> &mut Option<Vec<u32>> {
+        &mut self.matched_id_collection
     }
 }
 
@@ -285,6 +336,10 @@ mod watchlist_poster {
                     .map(Message::Poster)
                     .map(move |message| IndexedMessage::new(index, message)),
             )
+        }
+
+        pub fn get_series_info(&self) -> &SeriesMainInformation {
+            self.poster.get_series_info()
         }
 
         pub fn update(

--- a/src/gui/troxide_widget.rs
+++ b/src/gui/troxide_widget.rs
@@ -374,6 +374,10 @@ pub mod series_poster {
             )
         }
 
+        pub fn get_series_info(&self) -> &SeriesMainInformation {
+            self.poster.get_series_info()
+        }
+
         pub fn update(
             &mut self,
             message: IndexedMessage<usize, Message>,


### PR DESCRIPTION
This PR adds search bars to `Watchlist Tab`, `MyShows Tab` and `Statistics Tab` so as to make it easier to find a particular series in any of these tabs especially when they are alot.