### PR TITLE
UI tweak

### DIFF
--- a/src/gui/series_page/series/data_widgets.rs
+++ b/src/gui/series_page/series/data_widgets.rs
@@ -358,10 +358,14 @@ pub fn next_episode_to_air_widget(next_episode_to_air: Option<&Episode>) -> Elem
         ))
         .size(14);
 
-        container(row![clock_icon, text].spacing(5))
-            .style(styles::container_styles::second_class_container_square_theme())
-            .padding(5)
-            .into()
+        container(
+            row![clock_icon, text]
+                .align_items(Alignment::Center)
+                .spacing(5),
+        )
+        .style(styles::container_styles::second_class_container_square_theme())
+        .padding(5)
+        .into()
     } else {
         Space::new(0, 0).into()
     }

--- a/src/gui/series_page/series/people_widget/cast_widget.rs
+++ b/src/gui/series_page/series/people_widget/cast_widget.rs
@@ -347,8 +347,10 @@ mod cast_poster {
         fn image_switch_button(&self) -> Element<'_, Message> {
             if self.cast.character.image.is_some() {
                 let image_switch_button_handle = svg::Handle::from_memory(ARROW_REPEAT);
-                let icon =
-                    svg(image_switch_button_handle).style(styles::svg_styles::colored_svg_theme());
+                let icon = svg(image_switch_button_handle)
+                    .style(styles::svg_styles::colored_svg_theme())
+                    .width(20)
+                    .height(20);
 
                 let mut button =
                     button(icon).style(styles::button_styles::transparent_button_theme());

--- a/src/gui/series_page/series/season_widget.rs
+++ b/src/gui/series_page/series/season_widget.rs
@@ -123,7 +123,7 @@ mod season {
     use std::rc::Rc;
 
     use iced::widget::{button, checkbox, column, container, progress_bar, row, svg, text, Column};
-    use iced::{Command, Element, Length};
+    use iced::{Alignment, Command, Element, Length};
     use iced_aw::Spinner;
 
     use crate::core::api::tv_maze::episodes_information::Episode as EpisodeInfo;
@@ -321,6 +321,7 @@ mod season {
                 episodes_progress,
                 expand_button,
             ]
+            .align_items(Alignment::Center)
             .spacing(5);
 
             let mut content = column!(content);

--- a/src/gui/tabs/watchlist_tab.rs
+++ b/src/gui/tabs/watchlist_tab.rs
@@ -280,7 +280,7 @@ mod watchlist_poster {
         button, column, container, horizontal_rule, image, mouse_area, progress_bar, row, text,
         Space,
     };
-    use iced::{Command, Element, Length};
+    use iced::{Alignment, Command, Element, Length};
 
     use crate::core::api::tv_maze::series_information::SeriesMainInformation;
     use crate::core::caching::episode_list::EpisodeList;
@@ -448,6 +448,7 @@ mod watchlist_poster {
                     watched_episodes as f32, self.total_series_episodes as f32
                 ))
             ]
+            .align_items(Alignment::Center)
             .spacing(5);
 
             metadata = metadata.push(progress_bar);
@@ -602,6 +603,7 @@ mod watchlist_summary {
                     total_episodes_watched as f32, self.total_episodes as f32
                 ))
             ]
+            .align_items(Alignment::Center)
             .spacing(5);
 
             let content = column![


### PR DESCRIPTION
This PR improves the alignment of the seasons in the series page, posters in the watchlist tab and switch character buttons in the series page.